### PR TITLE
docs(user): add first draft guide for getting started

### DIFF
--- a/docs/users/00-getting-started.md
+++ b/docs/users/00-getting-started.md
@@ -51,7 +51,7 @@ spec:
 
 ### 3. Create a `ManagedControlPlane` in the `Workspace`
 
-The `ManagedControlPlane` resource is the heart of the openMCP platform. A Managed Control Plane (MCP) is a representation of a Kubernetes API. With the `ManagedControlPlane` you specify the Users that get access via ClusterRoles or Roles to the Kubernetes API of the MCP.
+The `ManagedControlPlane` resource is the heart of the openMCP platform. Each Managed Control Plane (MCP) has its own Kubernetes API endpoint and data store. You can use the `iam` property to define who should have access to the MCP and the resources it contains.
 
 ```yaml
 apiVersion: core.openmcp.cloud/v2alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a first draft guide to the end user documentation of how to get started. Please note that this guide is not complete and will extended in the future.

**Which issue(s) this PR fixes**:
Related https://github.com/openmcp-project/backlog/issues/49

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```