### PR TITLE
docs: add bootstrapping documentation

### DIFF
--- a/docs/operators/01-boostrapping.md
+++ b/docs/operators/01-boostrapping.md
@@ -549,7 +549,7 @@ status:
 ```
 
 You should see that the Managed Control Plane is in phase `Ready`.
-The openmcp-operator should now have created a new Kind cluster that represents the managed control plane.
+The openmcp-operator should now have created a new Kind cluster that represents the Managed Control Plane.
 You can check the list of available Kind clusters using the following command:
 
 ```shell
@@ -567,7 +567,7 @@ platform
 You can now get the kubeconfig of the managed control plane and save it to a file named `my-mcp.kubeconfig` in the kubeconfigs folder. Please replace `mcp-worker-abcde.87654321` with the actual name of your managed control plane cluster.
 
 ```shell
-kind get kubeconfig --name mcp-worker-fbmpf.040335d0 > ./kubeconfigs/my-mcp.kubeconfig
+kind get kubeconfig --name mcp-worker-abcde.87654321 > ./kubeconfigs/my-mcp.kubeconfig
 ```
 
 You can now use the kubeconfig to access the Managed Control Plane cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add documentation about bootstrapping concept and a bootstrapping example using the kind cluster provider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Add documentation about bootstrapping concept and a bootstrapping example using the kind cluster provider.
```