### PR TITLE
docs: add bootstrapping example using cluster provider gardener

### DIFF
--- a/docs/operators/01-boostrapping.md
+++ b/docs/operators/01-boostrapping.md
@@ -1122,7 +1122,7 @@ spec:
 
 The gardener landscape configuration requires a secret that contains the kubeconfig to access the Gardener project. For that purpose, create a secret named `gardener-landscape-kubeconfig` in the `openmcp-system` namespace of the platform cluster that contains the kubeconfig file that has access to the Gardener installation.
 See the [Gardener documentation](https://gardener.cloud/docs/dashboard/automated-resource-management/#create-a-service-account) on how to create a service account in the Gardener project using the Gardener dashboard.
-Create a service account with at least the `admin` role in the Gardener project. Then [download]((https://gardener.cloud/docs/dashboard/automated-resource-management/#use-the-service-account)) the kubeconfig for the service account and save it to a file named `./kubeconfigs/gardener-landscape.kubeconfig`.
+Create a service account with at least the `admin` role in the Gardener project. Then [download](https://gardener.cloud/docs/dashboard/automated-resource-management/#use-the-service-account) the kubeconfig for the service account and save it to a file named `./kubeconfigs/gardener-landscape.kubeconfig`.
 
 ```shell
 kubectl --kubeconfig ./kubeconfigs/platform.kubeconfig create namespace openmcp-system


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new section to the bootstrapping documentation that contains an example on how to bootstrap an openMCP landscaper with cluster provider gardener.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
Add bootstrapping example using cluster provider gardener
```