### PR TITLE
docs(end-user): add authentication methods for `ManagedControlPlane`

### DIFF
--- a/docs/users/00-getting-started.md
+++ b/docs/users/00-getting-started.md
@@ -80,7 +80,7 @@ spec:
 ```
 
 Under `spec.iam` you can define the authentication for your ManagedControlPlane. You can use OIDC-based authentication for human users and token-based authentication for machine users.
-In case of OIDC-based authentication, ClusterRoleBindings will get created that map the specified roles to the defined subjects. The same applies to token-based authentication where the specified roles will get bound to the generated ServiceAccount on the ManagedControlPlane.
+For authorization, ClusterRoleBindings will map the specified roles to the defined subjects. For token-based authentication, the specified roles will get bound to a generated ServiceAccount on the ManagedControlPlane.
 
 In `status.access` you will find the references to the secrets at the Onboarding API that contain the kubeconfig to access your MCP for the OIDC and/or token-based authentication methods.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simply adds more context how an end user can authenticate at the ManagedControlPlane via OIDC or token-based.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Add OIDC-based and token-based authentication options for ManagedControlPlane
```