### PR TITLE
docs: Update outdated bootstrapper git settings

### DIFF
--- a/docs/operators/01-boostrapping.md
+++ b/docs/operators/01-boostrapping.md
@@ -166,7 +166,7 @@ component:
 
 repository:
   url: https://github.com/<your-org>/<your-repo>
-  branch: <branch-name>
+  pushBranch: <branch-name>
 
 environment: <environment-name>
 
@@ -267,7 +267,7 @@ component:
 
 repository:
   url: https://github.com/<your-org>/<your-repo>
-  branch: <branch-name>
+  pushBranch: <branch-name>
 
 environment: <environment-name>
 
@@ -610,7 +610,7 @@ component:
 
 repository:
   url: https://github.com/<your-org>/<your-repo>
-  branch: <branch-name>
+  pushBranch: <branch-name>
 
 environment: <environment-name>
 
@@ -956,7 +956,7 @@ component:
 
 repository:
   url: https://github.com/<your-org>/<your-repo>
-  branch: <branch-name>
+  pushBranch: <branch-name>
 
 environment: <environment-name>
 
@@ -1061,7 +1061,7 @@ component:
 
 repository:
   url: https://github.com/<your-org>/<your-repo>
-  branch: <branch-name>
+  pushBranch: <branch-name>
 
 environment: <environment-name>
 
@@ -1863,7 +1863,7 @@ component:
 
 repository:
   url: https://github.com/<your-org>/<your-repo>
-  branch: <branch-name>
+  pushBranch: <branch-name>
 
 environment: <environment-name>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up on https://github.com/openmcp-project/bootstrapper/pull/137, replace outdated `branch` with `pushBranch` parameter in bootstrapping guide

**Which issue(s) this PR fixes**:

```bash
$ docker run --rm --network kind -v ./config:/config -v ./kubeconfigs:/kubeconfigs ghcr.io/openmcp-project/images/openmcp-bootstrapper:${OPENMCP_BOOTSTRAPPER_VERSION} deploy-flux --git-config /config/git-config.yaml --kubeconfig /kubeconfigs/platform-int.kubeconfig /config/bootstrapper-config.yaml


Info: Starting deployment of Flux controllers with config file: /config/bootstrapper-config.yaml.
Error: invalid config file: repository.pullBranch: Required value: repository pull branch is required
Usage:
  openmcp-bootstrapper deploy-flux [flags]

Examples:
  openmcp-bootstrapper deploy-flux "./config.yaml"

Flags:
      --ocm-config string   OCM configuration file
      --git-config string   Git credentials configuration file that configures basic auth or ssh private key. This will be used in the fluxcd GitSource for spec.secretRef to authenticate against the deploymentRepository. If not set, no authentication will be configured.
      --kubeconfig string   Kubernetes configuration file
  -h, --help                help for deploy-flux

Global Flags:
  -v, --verbosity string   Set the verbosity level (panic, fatal, error, warn, info, debug, trace) (default "info")
```

**Special notes for your reviewer**:

This is my first PR so I don't know if a release note is required. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```