### PR TITLE
docs(developers): service provider init build submodule

### DIFF
--- a/docs/developers/service-providers.md
+++ b/docs/developers/service-providers.md
@@ -36,9 +36,10 @@ go run ./cmd/template -v -module github.com/openmcp-project/service-provider-vel
 
 The template generates a fully functional service provider that can be executed and deployed on your local machine using [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind) and [openmcp-testing](https://github.com/openmcp-project/openmcp-testing).
 
-To run the the generated end-to-end test using [task](https://taskfile.dev/), execute:
+To run the the generated end-to-end test using [task](https://taskfile.dev/), init the [build](https://github.com/openmcp-project/build) submodule and execute the e2e test:
 
 ```bash
+git submodule update --init --recursive
 task test-e2e
 ```
 


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Adds missing step to init the build submodule to the service provider dev guide.

**Which issue(s) this PR fixes**:
Fixes #28 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Add missing init build module step to service provider dev guide
```