### PR TITLE
fix: added new warning about subnet size

### DIFF
--- a/docs/operators/01-boostrapping.md
+++ b/docs/operators/01-boostrapping.md
@@ -127,7 +127,7 @@ Create the Kind cluster using the configuration file created in the previous ste
 
 :::warning
 
-Please check if your current `kind` network is has a `/16` subnet. This is required for our cluster-provider-kind.
+Please check if your current `kind` network has a `/16` subnet. This is required for our cluster-provider-kind.
 You can check the current network configuration using:
 
 ```shell


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a warning about the subnet size as it needs to be `/16`.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
added a warning section about the subnet size for the local setup.
```