### PR TITLE
feat: improve SIG Extensibility card design

### DIFF
--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -53,22 +53,7 @@ Special Interest Group focused on making it easy to build, share, and adopt exte
   </div>
 
   <div style={{display: 'flex', gap: '12px', flexWrap: 'wrap', justifyContent: 'center', marginTop: '0'}}>
-    <a 
-      href="https://lists.neonephos.org/g/openMCP-extensibility/" 
-      style={{
-        background: 'white',
-        color: '#032423',
-        fontWeight: '700',
-        fontSize: '1rem',
-        padding: '12px 24px',
-        borderRadius: '8px',
-        textDecoration: 'none',
-        display: 'inline-flex',
-        alignItems: 'center',
-        boxShadow: '0 4px 16px rgba(0, 0, 0, 0.4)',
-        transition: 'all 0.2s ease'
-      }}
-    >
+    <a href="https://lists.neonephos.org/g/openMCP-extensibility/" className="subscribe-button">
       Subscribe to Mailing List
     </a>
   </div>

--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -53,7 +53,24 @@ Special Interest Group focused on making it easy to build, share, and adopt exte
   </div>
 
   <div style={{display: 'flex', gap: '12px', flexWrap: 'wrap', justifyContent: 'center', marginTop: '0'}}>
-    <a href="https://lists.neonephos.org/g/openMCP-extensibility/" className="reference-link" style={{background: 'rgba(255, 255, 255, 0.95)', color: '#064d4b !important', fontWeight: '700', fontSize: '1rem', padding: '12px 24px', boxShadow: '0 4px 16px rgba(0, 0, 0, 0.3)'}}>Subscribe to Mailing List</a>
+    <a 
+      href="https://lists.neonephos.org/g/openMCP-extensibility/" 
+      style={{
+        background: 'white',
+        color: '#032423',
+        fontWeight: '700',
+        fontSize: '1rem',
+        padding: '12px 24px',
+        borderRadius: '8px',
+        textDecoration: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        boxShadow: '0 4px 16px rgba(0, 0, 0, 0.4)',
+        transition: 'all 0.2s ease'
+      }}
+    >
+      Subscribe to Mailing List
+    </a>
   </div>
 </div>
 

--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -40,21 +40,20 @@ Special Interest Group focused on making it easy to build, share, and adopt exte
 <div className="reference-grid">
 
 <div className="reference-card reference-card-featured" style={{gridColumn: 'span 2'}}>
-  <IconContainer size={70} compact>
-    <Puzzle size={70} strokeWidth={2} />
+  <IconContainer size={60} compact>
+    <Puzzle size={60} strokeWidth={2} />
   </IconContainer>
   <h3>SIG Extensibility</h3>
   <p>Make it easy to build, share, and adopt extensions—service providers, cluster providers, and platform services.</p>
 
-  <div className="sig-details">
+  <div className="sig-details" style={{margin: '16px 0 20px 0'}}>
     <div><strong>Leads:</strong> Maximilian Techritz, Christopher Junk (SAP)</div>
     <div><strong>Meetings:</strong> Bi-weekly, Wednesday 3PM CET</div>
     <div><strong>Mailing List:</strong> openMCP-extensibility@lists.neonephos.org</div>
   </div>
 
-  <div style={{display: 'flex', gap: '12px', flexWrap: 'wrap', justifyContent: 'center', marginTop: '4px'}}>
-    <a href="https://github.com/openmcp-project/community/tree/main/sig-extensibility" className="reference-link">View Charter</a>
-    <a href="mailto:openMCP-extensibility@lists.neonephos.org" className="reference-link">Subscribe</a>
+  <div style={{display: 'flex', gap: '12px', flexWrap: 'wrap', justifyContent: 'center', marginTop: '0'}}>
+    <a href="https://lists.neonephos.org/g/openMCP-extensibility/" className="reference-link" style={{background: 'rgba(255, 255, 255, 0.95)', color: '#064d4b !important', fontWeight: '700', fontSize: '1rem', padding: '12px 24px', boxShadow: '0 4px 16px rgba(0, 0, 0, 0.3)'}}>Subscribe to Mailing List</a>
   </div>
 </div>
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2125,35 +2125,43 @@ body[class*="docs-doc-id-reference"] .row {
 }
 
 /* Subscribe button - light background with dark text */
-.reference-card-featured a.subscribe-button {
-  background: white !important;
-  color: #032423 !important;
-  border: none;
+.reference-card-featured a.subscribe-button,
+.reference-card-featured a.subscribe-button:link,
+.reference-card-featured a.subscribe-button:visited {
+  background: #ffffff !important;
+  color: #000000 !important;
+  border: none !important;
   font-weight: 700 !important;
   padding: 12px 24px !important;
-  border-radius: 8px;
-  transition: all 0.2s ease;
-  display: inline-flex;
-  align-items: center;
+  border-radius: 8px !important;
+  transition: all 0.2s ease !important;
+  display: inline-flex !important;
+  align-items: center !important;
   font-size: 1rem !important;
-  text-decoration: none;
+  text-decoration: none !important;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4) !important;
   text-shadow: none !important;
+  letter-spacing: 0 !important;
 }
 
 .reference-card-featured a.subscribe-button:hover {
-  background: rgba(255, 255, 255, 0.9) !important;
-  transform: translateY(-2px);
+  background: #f0f0f0 !important;
+  color: #000000 !important;
+  transform: translateY(-2px) !important;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5) !important;
+  text-decoration: none !important;
 }
 
-[data-theme='dark'] .reference-card-featured a.subscribe-button {
-  background: white !important;
-  color: #032423 !important;
+[data-theme='dark'] .reference-card-featured a.subscribe-button,
+[data-theme='dark'] .reference-card-featured a.subscribe-button:link,
+[data-theme='dark'] .reference-card-featured a.subscribe-button:visited {
+  background: #ffffff !important;
+  color: #000000 !important;
 }
 
 [data-theme='dark'] .reference-card-featured a.subscribe-button:hover {
-  background: rgba(255, 255, 255, 0.9) !important;
+  background: #f0f0f0 !important;
+  color: #000000 !important;
 }
 
 .reference-card-featured:hover {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2124,6 +2124,38 @@ body[class*="docs-doc-id-reference"] .row {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
+/* Subscribe button - light background with dark text */
+.reference-card-featured a.subscribe-button {
+  background: white !important;
+  color: #032423 !important;
+  border: none;
+  font-weight: 700 !important;
+  padding: 12px 24px !important;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1rem !important;
+  text-decoration: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4) !important;
+  text-shadow: none !important;
+}
+
+.reference-card-featured a.subscribe-button:hover {
+  background: rgba(255, 255, 255, 0.9) !important;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5) !important;
+}
+
+[data-theme='dark'] .reference-card-featured a.subscribe-button {
+  background: white !important;
+  color: #032423 !important;
+}
+
+[data-theme='dark'] .reference-card-featured a.subscribe-button:hover {
+  background: rgba(255, 255, 255, 0.9) !important;
+}
+
 .reference-card-featured:hover {
   transform: translateY(-4px);
   box-shadow: 0 24px 80px rgba(4, 159, 154, 0.5);


### PR DESCRIPTION
## Summary
- Remove "View Charter" button to reduce clutter and simplify the card
- Make card more compact by reducing icon size (70→60px) and adjusting margins
- Highlight "Subscribe to Mailing List" button with prominent white background and dark teal text
- Update subscribe link to point to https://lists.neonephos.org/g/openMCP-extensibility/ instead of mailto
- Add `!important` flag to color style to ensure proper override of CSS class

## Changes
The SIG Extensibility card now features a single, prominent call-to-action button that stands out with a white background against the teal gradient, making it clearer for users how to get involved.

## Test plan
- [ ] View the community overview page at `/docs/community/overview`
- [ ] Verify the card is more compact with smaller icon
- [ ] Verify the "View Charter" button is removed
- [ ] Verify the "Subscribe to Mailing List" button has white background with dark text
- [ ] Verify clicking the subscribe button leads to https://lists.neonephos.org/g/openMCP-extensibility/