### PR TITLE
docs: Document cluster types and important namespaces for provider/service development

### DIFF
--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -108,7 +108,7 @@ Each service provider must use a unique namespace per tenant service instance. F
 | `<provider>-<instance-id>` (e.g., `ls-system-<id>`) | Service provider workloads, isolated per tenant |
 
 :::info
-Newly developed services should prioritize deploying their workloads on Workload Clusters rather than MCP Clusters. See the [service provider design](./serviceprovider/design.md#deployment-model) for details.
+Newly developed services should prioritize deploying their workloads on Workload Clusters rather than MCP Clusters. See the [service provider design](./serviceprovider/04-design.mdx#deployment-model) for details.
 :::
 
 ## Real-World Examples

--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -15,7 +15,7 @@ OpenControlPlane uses four types of clusters, each with a distinct role:
 | **Onboarding** | User-facing API surface for managing Projects, Workspaces, and ControlPlanes | End users |
 | **Platform** | Runs all operators (openmcp-operator, service providers, cluster providers) and manages per-tenant resources | Platform operators, service provider developers |
 | **MCP** | Per-tenant lightweight Kubernetes cluster | End users |
-| **Workload** | Per-tenant cluster for running DomainService controllers (optional) | Service provider developers |
+| **Workload** | Shared multi-tenant cluster for running DomainService controllers (optional) | Service provider developers |
 
 ## Namespace Model
 
@@ -40,9 +40,7 @@ graph LR
     end
 
     subgraph MCPCluster["MCP (per tenant)"]
-        MN1["<b>crossplane-system</b><br/>Crossplane components"]
-        MN2["<b>ls-system-&lt;id&gt;</b><br/>Landscaper components"]
-        MN3["<b>flux-system</b><br/>Flux components"]
+        MN1["<b>service-specific namespace</b><br/>Service provider resources"]
     end
 
     subgraph WorkloadCluster["Workload (optional)"]
@@ -95,23 +93,19 @@ Each tenant gets a dedicated MCP (Managed Control Plane) Cluster — a lightweig
 
 | Namespace | Purpose |
 |-----------|---------|
-| `crossplane-system` | Crossplane components (installed by service-provider-crossplane) |
-| `ls-system-<instance-id>` | Landscaper components (installed by service-provider-landscaper) |
-| `flux-system` | Flux components |
-| `cert-manager` | cert-manager components |
-| `external-secrets` | External Secrets Operator |
+| Service-specific (e.g., `crossplane-system`, `ls-system-<id>`, `flux-system`) | Resources deployed by service providers and platform components |
 
 Each service provider chooses its own namespace on the MCP cluster — there is no single default namespace convention. For example, Crossplane uses the fixed namespace `crossplane-system`, while Landscaper derives an instance-specific namespace like `ls-system-<id>`. When building a new service provider, you decide which namespace to deploy your resources into.
 
 ### Workload Cluster
 
-Workload Clusters are optional per-tenant clusters provisioned on demand when a service provider requests them. They are used for running DomainService controllers outside the MCP cluster.
+Workload Clusters are shared multi-tenant clusters. Multiple service instances from different tenants can run on the same cluster, so tenant isolation via namespaces is required.
+
+Each service provider must use a unique namespace per tenant service instance. For example, by [hashing the tenant resource's name and namespace into an instance ID](#service-provider-landscaper-mcp--workload-cluster) and using it as a namespace suffix.
 
 | Namespace | Purpose |
 |-----------|---------|
-| Service-specific (e.g., `envoy-gateway-system`, `velero`) | Where DomainService controllers and their resources run |
-
-Each MCP that requests a workload cluster gets its own dedicated cluster, maintaining per-tenant isolation. Service providers choose their own namespace naming conventions on the workload cluster.
+| `<provider>-<instance-id>` (e.g., `ls-system-<id>`) | Service provider workloads, isolated per tenant |
 
 :::info
 Newly developed services should prioritize deploying their workloads on Workload Clusters rather than MCP Clusters. See the [service provider design](./serviceprovider/design.md#deployment-model) for details.

--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -14,7 +14,7 @@ OpenControlPlane uses four types of clusters, each with a distinct role:
 |---------|---------|-----------------|
 | **Onboarding** | User-facing API surface for managing Projects, Workspaces, and ControlPlanes | End users |
 | **Platform** | Runs all operators (openmcp-operator, service providers, cluster providers) and manages per-tenant resources | Platform operators, service provider developers |
-| **MCP** | Per-tenant lightweight Kubernetes cluster that hosts the DomainServiceAPI | End users (via DomainServiceAPI) |
+| **MCP** | Per-tenant lightweight Kubernetes cluster | End users |
 | **Workload** | Per-tenant cluster for running DomainService controllers (optional) | Service provider developers |
 
 ## Namespace Model
@@ -72,18 +72,18 @@ For example, a project named `platform-team` with a workspace `dev` results in:
 - `project-platform-team` for the project
 - `project-platform-team--ws-dev` for the workspace
 
-ServiceProviderAPI CRDs are installed on the Onboarding Cluster so that all tenants can discover available services.
+[Service Providers](../users/concepts/service-provider.md) install CRDs on the Onboarding Cluster so that all tenants can discover available services.
 
 ### Platform Cluster
 
-The Platform Cluster runs all operators and manages per-tenant resources:
+The Platform Cluster runs all operators. Tenant resources are isolated using namespaces:
 
 | Namespace | Purpose |
 |-----------|---------|
 | `openmcp-system` | System namespace where all provider pods (service providers, cluster providers, platform services) and the openmcp-operator run |
 | `mcp--<uuid>` | One per MCP tenant. Auto-generated using a deterministic SHAKE128 hash of the MCP name and namespace. Contains AccessRequests, ClusterRequests, and kubeconfig secrets scoped to that tenant |
 
-The `mcp--<uuid>` namespaces are created and managed automatically by the platform. The [service-provider-runtime](./serviceprovider/02-service-providers.mdx) resolves the correct tenant namespace via the [`ClusterContext`](./serviceprovider/02-service-providers.mdx#createorupdate-operation).
+The `mcp--<uuid>` namespaces are created and managed automatically by the platform.
 
 :::info
 The `POD_NAMESPACE` environment variable, available to all provider pods, refers to the provider's namespace on the Platform Cluster (typically `openmcp-system`). See the [deployment guide](./serviceprovider/01-deployment.mdx) for all available environment variables.

--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+id: clusters-and-namespaces
 ---
 
 # Clusters and Namespaces
@@ -139,5 +140,5 @@ Image pull secrets are copied from the pod namespace on the Platform Cluster to 
 The instance ID is a base32-encoded SHA1 hash of the Landscaper resource's namespace and name, producing a unique namespace per instance. Image pull secrets are synced from the pod namespace on the Platform Cluster to the instance namespace on the Workload Cluster.
 
 :::tip For Service Provider Developers
-You access MCP and Workload clusters via the [`ClusterContext`](./serviceprovider/02-service-providers.mdx#createorupdate-operation) provided by the service-provider-runtime. See the [service provider development guide](./serviceprovider/02-service-providers.mdx#cluster-and-namespace-context) for the full mapping.
+You access MCP and Workload clusters via the [`ClusterContext`](./serviceprovider/02-develop.mdx#createorupdate-operation) provided by the service-provider-runtime. See the [service provider development guide](./serviceprovider/02-develop.mdx#cluster-and-namespace-context) for the full mapping.
 :::

--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -1,0 +1,149 @@
+---
+sidebar_position: 1
+---
+
+# Clusters and Namespaces
+
+OpenControlPlane spans multiple Kubernetes clusters, each with its own namespace conventions.
+
+## Cluster Overview
+
+OpenControlPlane uses four types of clusters, each with a distinct role:
+
+| Cluster | Purpose | Primary Audience |
+|---------|---------|-----------------|
+| **Onboarding** | User-facing API surface for managing Projects, Workspaces, and ControlPlanes | End users |
+| **Platform** | Runs all operators (openmcp-operator, service providers, cluster providers) and manages per-tenant resources | Platform operators, service provider developers |
+| **MCP** | Per-tenant lightweight Kubernetes cluster that hosts the DomainServiceAPI | End users (via DomainServiceAPI) |
+| **Workload** | Per-tenant cluster for running DomainService controllers (optional) | Service provider developers |
+
+## Namespace Model
+
+The following diagram shows how namespaces are organized across all four cluster types:
+
+```mermaid
+---
+config:
+  themeVariables:
+    fontSize: 25px
+---
+graph LR
+    subgraph OnboardingCluster["Onboarding"]
+        ON1["<b>project-platform-team</b><br/>Workspaces, ServiceProviderAPIs"]
+        ON2["<b>project-platform-team--ws-dev</b><br/>ControlPlane resources"]
+    end
+
+    subgraph PlatformCluster["Platform"]
+        PN1["<b>openmcp-system</b><br/>All provider pods, operator"]
+        PN2["<b>mcp--&lt;uuid&gt;</b><br/>AccessRequests, secrets for Tenant A"]
+        PN3["<b>mcp--&lt;uuid&gt;</b><br/>AccessRequests, secrets for Tenant B"]
+    end
+
+    subgraph MCPCluster["MCP (per tenant)"]
+        MN1["<b>crossplane-system</b><br/>Crossplane components"]
+        MN2["<b>ls-system-&lt;id&gt;</b><br/>Landscaper components"]
+        MN3["<b>flux-system</b><br/>Flux components"]
+    end
+
+    subgraph WorkloadCluster["Workload (optional)"]
+        WN1["<b>service-specific namespace</b><br/>DomainService controllers"]
+    end
+
+    OnboardingCluster ~~~ PlatformCluster
+    MCPCluster ~~~ WorkloadCluster
+
+    style OnboardingCluster fill:#f0f9ff,stroke:#0284c7
+    style PlatformCluster fill:#fef3c7,stroke:#d97706
+    style MCPCluster fill:#f0fdf4,stroke:#16a34a
+    style WorkloadCluster fill:#fdf2f8,stroke:#db2777
+```
+
+### Onboarding Cluster
+
+The Onboarding Cluster is the entry point for end users. Namespaces follow a hierarchical pattern:
+
+| Namespace | Created By | Contains |
+|-----------|-----------|----------|
+| `project-<project-name>` | Creating a `Project` | Workspaces, project-scoped resources |
+| `project-<project-name>--ws-<workspace-name>` | Creating a `Workspace` | `ManagedControlPlaneV2` resources, ServiceProviderAPI instances |
+
+
+For example, a project named `platform-team` with a workspace `dev` results in:
+- `project-platform-team` for the project
+- `project-platform-team--ws-dev` for the workspace
+
+ServiceProviderAPI CRDs are installed on the Onboarding Cluster so that all tenants can discover available services.
+
+### Platform Cluster
+
+The Platform Cluster runs all operators and manages per-tenant resources:
+
+| Namespace | Purpose |
+|-----------|---------|
+| `openmcp-system` | System namespace where all provider pods (service providers, cluster providers, platform services) and the openmcp-operator run |
+| `mcp--<uuid>` | One per MCP tenant. Auto-generated using a deterministic SHAKE128 hash of the MCP name and namespace. Contains AccessRequests, ClusterRequests, and kubeconfig secrets scoped to that tenant |
+
+The `mcp--<uuid>` namespaces are created and managed automatically by the platform. The [service-provider-runtime](./serviceprovider/02-service-providers.mdx) resolves the correct tenant namespace via the [`ClusterContext`](./serviceprovider/02-service-providers.mdx#createorupdate-operation).
+
+:::info
+The `POD_NAMESPACE` environment variable, available to all provider pods, refers to the provider's namespace on the Platform Cluster (typically `openmcp-system`). See the [deployment guide](./serviceprovider/01-deployment.mdx) for all available environment variables.
+:::
+
+### MCP Cluster
+
+Each tenant gets a dedicated MCP (Managed Control Plane) Cluster — a lightweight Kubernetes cluster with its own API server and data store. This provides the strongest isolation boundary between tenants.
+
+| Namespace | Purpose |
+|-----------|---------|
+| `crossplane-system` | Crossplane components (installed by service-provider-crossplane) |
+| `ls-system-<instance-id>` | Landscaper components (installed by service-provider-landscaper) |
+| `flux-system` | Flux components |
+| `cert-manager` | cert-manager components |
+| `external-secrets` | External Secrets Operator |
+
+Each service provider chooses its own namespace on the MCP cluster — there is no single default namespace convention. For example, Crossplane uses the fixed namespace `crossplane-system`, while Landscaper derives an instance-specific namespace like `ls-system-<id>`. When building a new service provider, you decide which namespace to deploy your resources into.
+
+### Workload Cluster
+
+Workload Clusters are optional per-tenant clusters provisioned on demand when a service provider requests them. They are used for running DomainService controllers outside the MCP cluster.
+
+| Namespace | Purpose |
+|-----------|---------|
+| Service-specific (e.g., `envoy-gateway-system`, `velero`) | Where DomainService controllers and their resources run |
+
+Each MCP that requests a workload cluster gets its own dedicated cluster, maintaining per-tenant isolation. Service providers choose their own namespace naming conventions on the workload cluster.
+
+:::info
+Newly developed services should prioritize deploying their workloads on Workload Clusters rather than MCP Clusters. See the [service provider design](./serviceprovider/design.md#deployment-model) for details.
+:::
+
+## Real-World Examples
+
+The following examples show how two production service providers use namespaces across all cluster types.
+
+### service-provider-crossplane (MCP-only, no Workload Cluster)
+
+| Cluster | Namespace | What goes there |
+|---------|-----------|-----------------|
+| **Platform** | pod namespace (typically `openmcp-system`) | Provider pod; source for image pull secrets |
+| **Platform** | `mcp--<uuid>` (tenant namespace) | HelmRelease + OCIRepository for Flux; AccessRequest + kubeconfig secret; chart pull secrets |
+| **Onboarding** | `project-<p>--ws-<w>` | `Crossplane` ServiceProviderAPI objects |
+| **MCP** | `crossplane-system` (fixed) | Crossplane pods, provider pods, image pull secrets (copied from platform) |
+
+Image pull secrets are copied from the pod namespace on the Platform Cluster to `crossplane-system` on the MCP cluster.
+
+### service-provider-landscaper (MCP + Workload Cluster)
+
+| Cluster | Namespace | What goes there |
+|---------|-----------|-----------------|
+| **Platform** | pod namespace (typically `openmcp-system`) | Provider pod; source for image pull secrets |
+| **Platform** | `mcp--<uuid>` (tenant namespace) | AccessRequests for MCP and Workload cluster access |
+| **Onboarding** | `project-<p>--ws-<w>` | `Landscaper` ServiceProviderAPI objects |
+| **MCP** | `ls-system-<instance-id>` (derived) | Namespace + RBAC resources |
+| **Workload** | `ls-system-<instance-id>` (derived) | Landscaper controller, webhooks server, manifest-deployer, helm-deployer; config and kubeconfig Secrets; image pull secrets |
+
+The instance ID is a base32-encoded SHA1 hash of the Landscaper resource's namespace and name, producing a unique namespace per instance. Image pull secrets are synced from the pod namespace on the Platform Cluster to the instance namespace on the Workload Cluster.
+
+:::tip For Service Provider Developers
+You access MCP and Workload clusters via the [`ClusterContext`](./serviceprovider/02-service-providers.mdx#createorupdate-operation) provided by the service-provider-runtime. See the [service provider development guide](./serviceprovider/02-service-providers.mdx#cluster-and-namespace-context) for the full mapping.
+:::

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -22,6 +22,19 @@ A service provider consists of the following two major parts, similar to a regul
 
 For a visual overview of how these components fit into an OpenControlPlane installation, refer to the [service provider deployment model](https://openmcp-project.github.io/docs/about/design/service-provider#deployment-model).
 
+## Cluster and Namespace Context
+
+A service provider operates across multiple clusters. The following table shows which cluster each code-level accessor points to and what you typically find there:
+
+| Code Access | Cluster | What lives there |
+|-------------|---------|------------------|
+| `r.PlatformCluster` | Platform Cluster | ProviderConfig (cluster-scoped); image pull secrets (in pod namespace); AccessRequests and kubeconfig secrets (in the per-tenant `mcp--<uuid>` namespace) |
+| `r.OnboardingCluster` | Onboarding Cluster | ServiceProviderAPI objects in `project-<p>--ws-<w>` workspace namespaces |
+| `clusters.MCPCluster` | MCP Cluster (per tenant) | DomainServiceAPI CRDs and deployed resources in a namespace you choose (e.g., `crossplane-system`) |
+| `clusters.WorkloadCluster` | Workload Cluster (per tenant/shared, optional) | DomainService controller workloads in a namespace you choose |
+
+For a complete overview of namespaces across all cluster types, including real-world examples, see [Clusters and Namespaces](../clusters-and-namespaces.md).
+
 ## Prerequisites
 
 Start by creating a new repository for your service provider using the [service-provider-template](https://github.com/openmcp-project/service-provider-template). Click "Use this template" button on the GitHub page and give your new repository a name that reflects the domain service it provides, e.g. `service-provider-velero` for a service provider that deploys Velero.

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -31,7 +31,7 @@ A service provider operates across multiple clusters. The following table shows 
 | `r.PlatformCluster` | Platform Cluster | ProviderConfig (cluster-scoped); image pull secrets (in pod namespace); AccessRequests and kubeconfig secrets (in the per-tenant `mcp--<uuid>` namespace) |
 | `r.OnboardingCluster` | Onboarding Cluster | ServiceProviderAPI objects in `project-<p>--ws-<w>` workspace namespaces |
 | `clusters.MCPCluster` | MCP Cluster (per tenant) | DomainServiceAPI CRDs and deployed resources in a namespace you choose (e.g., `crossplane-system`) |
-| `clusters.WorkloadCluster` | Workload Cluster (per tenant/shared, optional) | DomainService controller workloads in a namespace you choose |
+| `clusters.WorkloadCluster` | Workload Cluster (shared, optional) | DomainService controller workloads in a namespace you choose |
 
 For a complete overview of namespaces across all cluster types, including real-world examples, see [Clusters and Namespaces](../clusters-and-namespaces.md).
 

--- a/docs/developers/serviceprovider/04-design.mdx
+++ b/docs/developers/serviceprovider/04-design.mdx
@@ -161,6 +161,8 @@ graph TD
     Crossplane -->|reconciles|Bucket
 ```
 
+For detailed namespace documentation across all cluster types, see [Clusters and Namespaces](../clusters-and-namespaces.md).
+
 :::info
 In the long term, the goal is to deploy every `DomainService` on `WorkloadClusters`. Newly developed services should prioritize deploying their workloads on `WorkloadClusters` rather than `MCPClusters`.
 :::


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a "Clusters and Namespaces" page to the developers section documenting how namespaces are used across cluster types.
**Which issue(s) this PR fixes**:
Fixes #33

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
Add documentation for cluster and namespace conventions across all OpenControlPlane cluster types
```