### PR TITLE
docs: document ProviderConfig guidelines and current state

### DIFF
--- a/docs/developers/clusterprovider/04-design.mdx
+++ b/docs/developers/clusterprovider/04-design.mdx
@@ -10,4 +10,4 @@ Detailed design documentation for Cluster Providers is coming soon.
 
 Cluster Providers are responsible for managing Kubernetes clusters and providing access to them within the OpenControlPlane ecosystem. They follow similar architectural patterns to Service Providers.
 
-For reference, you can review the [Service Provider Design Documentation](../serviceprovider/design.md) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.
+For reference, you can review the [Service Provider Design Documentation](../serviceprovider/04-design.mdx) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.

--- a/docs/developers/platformprovider/05-design.mdx
+++ b/docs/developers/platformprovider/05-design.mdx
@@ -10,4 +10,4 @@ Detailed design documentation for Platform Providers is coming soon.
 
 Platform Providers deliver complete platform capabilities within the OpenControlPlane ecosystem. They follow similar architectural patterns to Service Providers and Cluster Providers.
 
-For reference, you can review the [Service Provider Design Documentation](../serviceprovider/design.md) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.
+For reference, you can review the [Service Provider Design Documentation](../serviceprovider/04-design.mdx) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.

--- a/docs/developers/serviceprovider/02-service-providers.mdx
+++ b/docs/developers/serviceprovider/02-service-providers.mdx
@@ -169,7 +169,7 @@ Service providers must expose a `ProviderConfig` which platform operators use to
 
 ### ProviderConfig Guidelines
 
-When designing your `ProviderConfig`, **only include controller operational settings** -  configuration that controls how your controller reconciles, not what it deploys or what tenants can use.
+When designing your `ProviderConfig`, **only include controller operational settings** - configuration that controls how your controller reconciles, not what it deploys or what tenants can use.
 Operational settings include reconciliation behavior, timeouts, observability, feature toggles, and trust configuration (CA bundles).
 
 **Do not include** deployment artifacts (images, charts, versions) or tenant constraints (version policies, available providers).
@@ -219,7 +219,7 @@ spec:
       versions: ["v1.13.0"]
       image: "velero/velero-plugin-for-aws"
 
-  # DEPLOYMENT SPECIFIC (temporary — will move to separate API)
+  # DEPLOYMENT ARTIFACTS (temporary — will move to separate API)
   imagePullSecrets:
     - name: privateregcred
 ```

--- a/docs/developers/serviceprovider/02-service-providers.mdx
+++ b/docs/developers/serviceprovider/02-service-providers.mdx
@@ -167,9 +167,31 @@ type ManagedResource struct {
 
 Service providers must expose a `ProviderConfig` which platform operators use to configure provider behavior. Because [provider deployment](https://openmcp-project.github.io/docs/developers/provider_deployment/) does not support passing arguments to the binary directly, configuration must be expressed via this API.
 
-Typical settings include version constraints, image locations and pull secrets which are especially important to support air-gapped environments.
+:::warning Important Design Consideration
+The current `ProviderConfig` pattern in many existing Service Providers incorrectly mixes three separate concerns:
+1. **Controller operational configuration** (correct — belongs in ProviderConfig)
+2. **Deployment artifacts** like image URLs and chart locations (incorrect — should live in future Registry API, tracked in [backlog#384](https://github.com/openmcp-project/backlog/issues/384))
+3. **Tenant constraints** like `allowedProviders` or version policies (incorrect — should live in future TenantPolicy/ServiceOffering concept)
 
-For example, Velero also implicitly defines the available plugins via the `ProviderConfig`.
+When designing your `ProviderConfig`, **only include controller operational settings** — configuration that controls how your controller reconciles, not what it deploys or what tenants can use. Structure your API to allow graceful deprecation of deployment and constraint fields when the Registry and TenantPolicy systems become available. See the [ProviderConfig Guidelines](./design#serviceproviderconfig-guidelines) for detailed recommendations.
+:::
+
+ProviderConfig should contain **controller operational settings only**, such as:
+- **Reconciliation behavior**: `pollInterval`, `maxConcurrentReconciles`, `requeueAfter`
+- **Timeouts and retries**: `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout`
+- **Observability**: `enableMetrics`, `logLevel`, `enableTracing`
+- **Controller features**: `enableDriftDetection`, `enableStatusReporting`
+- **Platform secrets**: `imagePullSecrets`, `caBundleRef` (for controller operation)
+
+:::info Current Temporary Necessity
+Many existing Service Providers also include deployment artifacts (image/chart URLs, version lists) and tenant constraints (`allowedProviders`, version policies) in their ProviderConfig. These are **temporary inclusions** that will eventually move to separate systems:
+- **Deployment artifacts** → Future Registry/ComponentCatalog API
+- **Tenant constraints** → Future TenantPolicy/ServiceOffering concept
+
+When creating a new Service Provider, clearly document which fields are operational (permanent) vs. artifacts/constraints (temporary).
+:::
+
+For example, Velero's ProviderConfig currently includes both operational settings and deployment artifacts:
 
 ```yaml
 apiVersion: velero.services.openmcp.cloud/v1alpha1
@@ -177,7 +199,10 @@ kind: ProviderConfig
 metadata:
   name: default
 spec:
+  # OPERATIONAL SETTINGS (correct — permanent)
   pollInterval: 1m
+
+  # DEPLOYMENT ARTIFACTS (temporary — will move to Registry)
   availableImages:
     - name: velero
       versions: ["v1.17.1"]
@@ -185,6 +210,8 @@ spec:
     - name: aws
       versions: ["v1.13.0"]
       image: "velero/velero-plugin-for-aws"
+
+  # PLATFORM SECRETS (correct — for controller operation)
   imagePullSecrets:
     - name: privateregcred
 ```

--- a/docs/developers/serviceprovider/02-service-providers.mdx
+++ b/docs/developers/serviceprovider/02-service-providers.mdx
@@ -171,11 +171,32 @@ Service providers must expose a `ProviderConfig` which platform operators use to
 
 The `ProviderConfig` API is **subject to change** as the platform evolves. A future Registry/Marketplace concept ([backlog#384](https://github.com/openmcp-project/backlog/issues/384)) will handle deployment artifacts, and a TenantPolicy/ServiceOffering concept will handle tenant constraints. Until then, some Service Providers include these concerns in their `ProviderConfig` as a temporary measure.
 
-When designing your `ProviderConfig`, aim for the **ideal minimal structure** that contains only controller operational settings. See the [ProviderConfig Guidelines](./design#serviceproviderconfig-guidelines) for detailed design recommendations.
+When designing your `ProviderConfig`, **only include controller operational settings** — configuration that controls how your controller reconciles, not what it deploys or what tenants can use. Structure your API to allow graceful deprecation of deployment artifact and tenant constraint fields when the Registry and TenantPolicy systems become available.
+
+### ProviderConfig Guidelines
+
+#### What SHOULD be in ProviderConfig
+
+| Category | Fields | Purpose |
+|----------|--------|---------|
+| **Reconciliation** | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter` | Control reconcile frequency and parallelism |
+| **Timeouts** | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout` | Prevent hung operations |
+| **Observability** | `enableMetrics`, `logLevel`, `enableTracing` | Controller diagnostics |
+| **Features** | `enableDriftDetection`, `enableStatusReporting` | Toggle controller behaviors |
+| **Trust** | `caBundleRef` | Access to registries and trust bundles |
+
+#### What SHOULD NOT be in ProviderConfig
+
+The following do **not** belong in ProviderConfig and will move to dedicated systems:
+
+| Category | Examples | Future Home |
+|----------|----------|-------------|
+| **Deployment Artifacts** | Image URLs, chart URLs, version lists | Registry API ([backlog#384](https://github.com/openmcp-project/backlog/issues/384)) |
+| **Tenant Constraints** | [`availableProviders`](https://github.com/openmcp-project/service-provider-crossplane) in service-provider-crossplane, version policies | TenantPolicy/ServiceOffering |
 
 ### Ideal Minimal ProviderConfig
 
-A well-designed `ProviderConfig` contains **only controller operational settings** — configuration that controls how your ServiceProvider controller reconciles, not what it deploys:
+A well-designed `ProviderConfig` contains **only controller operational settings**:
 
 ```yaml
 apiVersion: myservice.services.openmcp.cloud/v1alpha1
@@ -190,16 +211,6 @@ spec:
   # Timeouts
   helmReleaseTimeout: 10m
 ```
-
-**Recommended operational fields:**
-
-| Category | Fields | Purpose |
-|----------|--------|---------|
-| Reconciliation | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter` | Control reconcile frequency and parallelism |
-| Timeouts | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout` | Prevent hung operations |
-| Observability | `enableMetrics`, `logLevel`, `enableTracing` | Controller diagnostics |
-| Features | `enableDriftDetection`, `enableStatusReporting` | Toggle controller behaviors |
-| Trust | `caBundleRef` | Access to registries and trust bundles |
 
 ### Current State: When You Need More
 

--- a/docs/developers/serviceprovider/02-service-providers.mdx
+++ b/docs/developers/serviceprovider/02-service-providers.mdx
@@ -167,32 +167,17 @@ type ManagedResource struct {
 
 Service providers must expose a `ProviderConfig` which platform operators use to configure provider behavior. Because [provider deployment](https://openmcp-project.github.io/docs/developers/provider_deployment/) does not support passing arguments to the binary directly, configuration must be expressed via this API.
 
-### Understanding ProviderConfig
-
-The `ProviderConfig` API is **subject to change** as the platform evolves. A future Registry/Marketplace concept ([backlog#384](https://github.com/openmcp-project/backlog/issues/384)) will handle deployment artifacts, and a TenantPolicy/ServiceOffering concept will handle tenant constraints. Until then, some Service Providers include these concerns in their `ProviderConfig` as a temporary measure.
-
-When designing your `ProviderConfig`, **only include controller operational settings** — configuration that controls how your controller reconciles, not what it deploys or what tenants can use. Structure your API to allow graceful deprecation of deployment artifact and tenant constraint fields when the Registry and TenantPolicy systems become available.
-
 ### ProviderConfig Guidelines
 
-#### What SHOULD be in ProviderConfig
+When designing your `ProviderConfig`, **only include controller operational settings** -  configuration that controls how your controller reconciles, not what it deploys or what tenants can use.
+Operational settings include reconciliation behavior, timeouts, observability, feature toggles, and trust configuration (CA bundles).
 
-| Category | Fields | Purpose |
-|----------|--------|---------|
-| **Reconciliation** | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter` | Control reconcile frequency and parallelism |
-| **Timeouts** | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout` | Prevent hung operations |
-| **Observability** | `enableMetrics`, `logLevel`, `enableTracing` | Controller diagnostics |
-| **Features** | `enableDriftDetection`, `enableStatusReporting` | Toggle controller behaviors |
-| **Trust** | `caBundleRef` | Access to registries and trust bundles |
+**Do not include** deployment artifacts (images, charts, versions) or tenant constraints (version policies, available providers).
 
-#### What SHOULD NOT be in ProviderConfig
+:::info Temporary Necessity
+Information about deployment artifacts and tenant constraints will move to dedicated Registry and TenantPolicy systems in the future (see [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)). Until then, some Service Providers include these concerns in their `ProviderConfig` as a temporary measure. Structure your API to allow graceful deprecation of deployment artifact and tenant constraint fields when the Registry and TenantPolicy systems become available.
+:::
 
-The following do **not** belong in ProviderConfig and will move to dedicated systems:
-
-| Category | Examples | Future Home |
-|----------|----------|-------------|
-| **Deployment Artifacts** | Image URLs, chart URLs, version lists | Registry API ([backlog#384](https://github.com/openmcp-project/backlog/issues/384)) |
-| **Tenant Constraints** | [`availableProviders`](https://github.com/openmcp-project/service-provider-crossplane) in service-provider-crossplane, version policies | TenantPolicy/ServiceOffering |
 
 ### Ideal Minimal ProviderConfig
 
@@ -214,15 +199,6 @@ spec:
 
 ### Current State: When You Need More
 
-:::info Temporary Necessity
-Many existing Service Providers include deployment artifacts (image/chart URLs, version lists) in their `ProviderConfig`. This is a **temporary pattern** until the Registry API becomes available. If your service requires version selection or artifact configuration, you may need to include these fields today.
-
-When doing so:
-1. **Document clearly** which fields are operational (permanent) vs. artifacts (temporary)
-2. **Structure your API** with separate nested objects to enable future deprecation
-3. **Use comments** in your Go types to mark temporary fields
-:::
-
 For example, Velero's ProviderConfig currently includes both operational settings and deployment artifacts:
 
 ```yaml
@@ -234,7 +210,7 @@ spec:
   # OPERATIONAL SETTINGS (correct — permanent)
   pollInterval: 1m
 
-  # DEPLOYMENT ARTIFACTS (temporary — will move to Registry)
+  # DEPLOYMENT ARTIFACTS (temporary — will move to separate API)
   availableImages:
     - name: velero
       versions: ["v1.17.1"]
@@ -243,7 +219,7 @@ spec:
       versions: ["v1.13.0"]
       image: "velero/velero-plugin-for-aws"
 
-  # DEPLOYMENT SPECIFIC (temporary — will move to Registry)
+  # DEPLOYMENT SPECIFIC (temporary — will move to separate API)
   imagePullSecrets:
     - name: privateregcred
 ```

--- a/docs/developers/serviceprovider/02-service-providers.mdx
+++ b/docs/developers/serviceprovider/02-service-providers.mdx
@@ -167,28 +167,49 @@ type ManagedResource struct {
 
 Service providers must expose a `ProviderConfig` which platform operators use to configure provider behavior. Because [provider deployment](https://openmcp-project.github.io/docs/developers/provider_deployment/) does not support passing arguments to the binary directly, configuration must be expressed via this API.
 
-:::warning Important Design Consideration
-The current `ProviderConfig` pattern in many existing Service Providers incorrectly mixes three separate concerns:
-1. **Controller operational configuration** (correct — belongs in ProviderConfig)
-2. **Deployment artifacts** like image URLs and chart locations (incorrect — should live in future Registry API, tracked in [backlog#384](https://github.com/openmcp-project/backlog/issues/384))
-3. **Tenant constraints** like `allowedProviders` or version policies (incorrect — should live in future TenantPolicy/ServiceOffering concept)
+### Understanding ProviderConfig
 
-When designing your `ProviderConfig`, **only include controller operational settings** — configuration that controls how your controller reconciles, not what it deploys or what tenants can use. Structure your API to allow graceful deprecation of deployment and constraint fields when the Registry and TenantPolicy systems become available. See the [ProviderConfig Guidelines](./design#serviceproviderconfig-guidelines) for detailed recommendations.
-:::
+The `ProviderConfig` API is **subject to change** as the platform evolves. A future Registry/Marketplace concept ([backlog#384](https://github.com/openmcp-project/backlog/issues/384)) will handle deployment artifacts, and a TenantPolicy/ServiceOffering concept will handle tenant constraints. Until then, some Service Providers include these concerns in their `ProviderConfig` as a temporary measure.
 
-ProviderConfig should contain **controller operational settings only**, such as:
-- **Reconciliation behavior**: `pollInterval`, `maxConcurrentReconciles`, `requeueAfter`
-- **Timeouts and retries**: `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout`
-- **Observability**: `enableMetrics`, `logLevel`, `enableTracing`
-- **Controller features**: `enableDriftDetection`, `enableStatusReporting`
-- **Platform secrets**: `imagePullSecrets`, `caBundleRef` (for controller operation)
+When designing your `ProviderConfig`, aim for the **ideal minimal structure** that contains only controller operational settings. See the [ProviderConfig Guidelines](./design#serviceproviderconfig-guidelines) for detailed design recommendations.
 
-:::info Current Temporary Necessity
-Many existing Service Providers also include deployment artifacts (image/chart URLs, version lists) and tenant constraints (`allowedProviders`, version policies) in their ProviderConfig. These are **temporary inclusions** that will eventually move to separate systems:
-- **Deployment artifacts** → Future Registry/ComponentCatalog API
-- **Tenant constraints** → Future TenantPolicy/ServiceOffering concept
+### Ideal Minimal ProviderConfig
 
-When creating a new Service Provider, clearly document which fields are operational (permanent) vs. artifacts/constraints (temporary).
+A well-designed `ProviderConfig` contains **only controller operational settings** — configuration that controls how your ServiceProvider controller reconciles, not what it deploys:
+
+```yaml
+apiVersion: myservice.services.openmcp.cloud/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  # Reconciliation behavior
+  pollInterval: 1m
+  maxConcurrentReconciles: 5
+
+  # Timeouts
+  helmReleaseTimeout: 10m
+```
+
+**Recommended operational fields:**
+
+| Category | Fields | Purpose |
+|----------|--------|---------|
+| Reconciliation | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter` | Control reconcile frequency and parallelism |
+| Timeouts | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout` | Prevent hung operations |
+| Observability | `enableMetrics`, `logLevel`, `enableTracing` | Controller diagnostics |
+| Features | `enableDriftDetection`, `enableStatusReporting` | Toggle controller behaviors |
+| Trust | `caBundleRef` | Access to registries and trust bundles |
+
+### Current State: When You Need More
+
+:::info Temporary Necessity
+Many existing Service Providers include deployment artifacts (image/chart URLs, version lists) in their `ProviderConfig`. This is a **temporary pattern** until the Registry API becomes available. If your service requires version selection or artifact configuration, you may need to include these fields today.
+
+When doing so:
+1. **Document clearly** which fields are operational (permanent) vs. artifacts (temporary)
+2. **Structure your API** with separate nested objects to enable future deprecation
+3. **Use comments** in your Go types to mark temporary fields
 :::
 
 For example, Velero's ProviderConfig currently includes both operational settings and deployment artifacts:
@@ -211,7 +232,7 @@ spec:
       versions: ["v1.13.0"]
       image: "velero/velero-plugin-for-aws"
 
-  # PLATFORM SECRETS (correct — for controller operation)
+  # DEPLOYMENT SPECIFIC (temporary — will move to Registry)
   imagePullSecrets:
     - name: privateregcred
 ```

--- a/docs/developers/serviceprovider/04-design.mdx
+++ b/docs/developers/serviceprovider/04-design.mdx
@@ -138,113 +138,18 @@ All operator tasks may be partially or fully automated.
 The `ServiceProvider` object itself is a higher level platform concept that is described in the corresponding `PlatformService`, i.e. [openmcp-operator](https://github.com/openmcp-project/openmcp-operator). The `ServiceProvider` handles deployment concerns (image, replicas, pull secrets for the controller), while `ProviderConfig` handles runtime operational concerns (poll intervals, timeouts, controller features).
 :::
 
-#### ServiceProviderConfig Guidelines
+#### ProviderConfig Scope
 
-When designing a `ProviderConfig` for your Service Provider, follow these guidelines to ensure consistency and maintainability across the platform.
+A `ProviderConfig` should **only** contain **controller operational settings** — configuration that controls how the ServiceProvider controller reconciles, not what it deploys or what tenants can use.
 
-##### What SHOULD be in ProviderConfig
+:::info Current State
+Current `ProviderConfig` implementations mix operational configuration with deployment artifacts (image URLs, chart locations) and tenant constraints (allowed providers, version policies). This is a temporary pattern. Future work will introduce proper separation:
 
-ProviderConfig should **only** contain **controller operational configuration** — settings that control how the ServiceProvider controller behaves, not what it deploys or what users/tenants can use.
+- **[backlog#384](https://github.com/openmcp-project/backlog/issues/384)**: Discoverability of Open Control Plane components
+- **TenantPolicy/ServiceOffering**: Concept for tenant constraints and service offerings (tbd)
 
-| Category                       | Description                                | Examples                                                    |
-| ------------------------------ | ------------------------------------------ | ----------------------------------------------------------- |
-| **Reconciliation Behavior**    | How the controller reconciles resources    | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter`   |
-| **Retry & Timeouts**           | Controller retry and timeout configuration | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout`    |
-| **Observability Settings**     | Controller metrics, logging, and tracing   | `enableMetrics`, `metricsPort`, `logLevel`, `enableTracing` |
-| **Controller Feature Toggles** | Enable/disable controller-level features   | `enableDriftDetection`                                      |
-
-##### What SHOULD NOT be in ProviderConfig
-
-:::warning Current State vs. Pure Design
-The current `ProviderConfig` implementations across the project mix controller operational configuration with deployment artifacts and tenant constraints. This section clarifies what does NOT belong in ProviderConfig and where it should live instead. Future work tracked in [backlog#384](https://github.com/openmcp-project/backlog/issues/384) will introduce proper separation of concerns.
+Until these systems are available, Service Providers may need to include these concerns in their `ProviderConfig`. See the [Developer Guide](./02-service-providers.mdx#understanding-providerconfig) for practical guidelines on structuring your `ProviderConfig`.
 :::
-
-The following information does **NOT** belong in ProviderConfig:
-
-| Category                                                                                         | Why It Doesn't Belong                                                       | Where It Should Live                            | Current State                                    |
-| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
-| **Deployment Artifacts**                                                                         | Controller doesn't need to know about images/charts — just how to reconcile | Future **Registry/ComponentCatalog** API        | Currently embedded in ProviderConfig (incorrect) |
-| - Image URLs                                                                                     | Artifact location is deployment concern, not controller behavior            | Registry                                        | `availableImages`, `versions[].image.url`        |
-| - Chart URLs                                                                                     | Same as image URLs                                                          | Registry                                        | `chartUrl`, `versions[].chart.url`               |
-| - Available Versions                                                                             | Not controller behavior                                                     | Registry + TenantPolicy/ServiceOffering         | Explicit version lists                           |
-| **Tenant Constraints**                                                                           | What tenants can or cannot use — not controller operational behavior        | Future **TenantPolicy/ServiceOffering** concept | Currently embedded in ProviderConfig (incorrect) |
-| - Allowed domain service specific extensions such as Crossplane Providers or Velero Plugins etc. | Tenant domain constraint, not controller setting                            | TenantPolicy/ServiceOffering                    | `allowedProviders`                               |
-| - Version Constraints                                                                            | Business policy, not controller behavior                                    | TenantPolicy/ServiceOffering                    | `minVersion`, `maxVersion`, `versionPolicy`      |
-| - Feature Access Control                                                                         | Domain-level tenant restrictions                                            | TenantPolicy/ServiceOffering                    | Various feature flags                            |
-
-##### Design Implications
-
-1. **For Service Provider Contributors**: When creating a new Service Provider today, you will need to temporarily include deployment artifacts (images, charts, versions) and potentially tenant constraints in your `ProviderConfig`. This is a known limitation. Structure your API so these fields can be gracefully deprecated when the Registry API and TenantPolicy/ServiceOffering concepts become available. Clearly document which fields are operational (permanent) vs. artifacts/constraints (temporary).
-
-2. **For Platform Operators**: Current `ProviderConfig` resources mix operational settings with deployment artifacts and tenant constraints. The operational settings (pollInterval, timeouts, retries) configure controller behavior and will remain. The artifacts and constraints will eventually move to separate systems.
-
-3. **For Version Updates**: Adding support for a new service version currently requires updating the `ProviderConfig`. In the future, the Registry will handle artifact discovery, and TenantPolicy/ServiceOffering will handle what tenants can use.
-
-##### Example: Current vs. Pure ProviderConfig
-
-**Current State** (mixed concerns — deployment artifacts + tenant constraints + operational config):
-
-```yaml
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  # OPERATIONAL (correct — belongs here)
-  pollInterval: 1m
-  maxConcurrentReconciles: 5
-  helmReleaseTimeout: 10m
-
-  # DEPLOYMENT ARTIFACTS (incorrect — should live in Registry)
-  versions:
-    - version: "1.18.0"
-      chart:
-        url: oci://ghcr.io/crossplane/crossplane
-        secretRef:
-          name: registry-credentials
-      image:
-        url: crossplane/crossplane:v1.18.0
-        secretRef:
-          name: registry-credentials
-
-  # TENANT CONSTRAINTS (incorrect — should live in TenantPolicy/ServiceOffering)
-  providers:
-    allowedProviders:
-      - provider-kubernetes
-      - provider-helm
-```
-
-**Future State** (pure operational configuration only):
-
-```yaml
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  # Controller operational settings only
-  pollInterval: 1m
-  maxConcurrentReconciles: 5
-  helmReleaseTimeout: 10m
-  retryBackoff:
-    initialInterval: 5s
-    maxInterval: 5m
-  enableMetrics: true
-  logLevel: info
-```
-
-**Deployment artifacts** move to separate API (backlog#384):
-
-tbd
-
-**Tenant constraints** move to TenantPolicy/ServiceOffering concept:
-
-tbd
-
-##### Related Issues and Future Work
-
-- [backlog#384: Discoverability of Open Control Plane components](https://github.com/openmcp-project/backlog/issues/384) — Will introduce Registry API for deployment artifacts
-- Future TenantPolicy/ServiceOffering concept — Will separate tenant constraints from controller configuration
 
 ### Service Discovery and Access Management
 

--- a/docs/developers/serviceprovider/04-design.mdx
+++ b/docs/developers/serviceprovider/04-design.mdx
@@ -78,47 +78,7 @@ sequenceDiagram
 
 ### Config
 
-The configuration of a Service Provider involves two distinct resources that serve different purposes:
-
-#### ServiceProvider vs. ProviderConfig
-
-It is important to understand the separation between the `ServiceProvider` CRD and the `ProviderConfig` CRD:
-
-| Resource            | API Group                                   | Purpose                                                 | Managed By        |
-| ------------------- | ------------------------------------------- | ------------------------------------------------------- | ----------------- |
-| **ServiceProvider** | `openmcp.cloud/v1alpha1`                    | How to deploy the ServiceProvider controller itself     | openmcp-operator  |
-| **ProviderConfig**  | `<service>.services.openmcp.cloud/v1alpha1` | How the deployed controller should behave operationally | Platform Operator |
-
-**ServiceProvider** (managed by openmcp-operator) defines the controller deployment:
-
-```yaml
-apiVersion: openmcp.cloud/v1alpha1
-kind: ServiceProvider
-metadata:
-  name: external-secrets
-spec:
-  # Controller image to deploy
-  image: .../service-provider-external-secrets:v0.1.0@sha256:...
-  # Secrets for pulling the CONTROLLER image
-  imagePullSecrets:
-    - name: artifactory
-  # Controller replicas
-  runReplicas: 1
-  # Controller log verbosity
-  verbosity: debug
-```
-
-**ProviderConfig** (managed by Platform Operator) defines controller operational behavior:
-
-```yaml
-apiVersion: externalsecrets.services.openmcp.cloud/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  # How the controller reconciles
-  pollInterval: 1m
-```
+A `ServiceProvider` defines a `ServiceProviderConfig` that contains provider-specific operational settings, allowing platform operators to configure a provider for different deployment scenarios. One scenario could be to specify pull secrets for operations in private or air-gapped environments. A `ServiceProviderConfig` does **not** configure valid end-user input values to define different service offerings for different tenants (see [Service Discovery and Access Management](#service-discovery-and-access-management)).
 
 ```mermaid
 graph LR
@@ -138,26 +98,13 @@ All operator tasks may be partially or fully automated.
 The `ServiceProvider` object itself is a higher level platform concept that is described in the corresponding `PlatformService`, i.e. [openmcp-operator](https://github.com/openmcp-project/openmcp-operator). The `ServiceProvider` handles deployment concerns (image, replicas, pull secrets for the controller), while `ProviderConfig` handles runtime operational concerns (poll intervals, timeouts, controller features).
 :::
 
-#### ProviderConfig Scope
-
-A `ProviderConfig` should **only** contain **controller operational settings** — configuration that controls how the ServiceProvider controller reconciles, not what it deploys or what tenants can use.
-
-:::info Current State
-Current `ProviderConfig` implementations mix operational configuration with deployment artifacts (image URLs, chart locations) and tenant constraints (allowed providers, version policies). This is a temporary pattern. Future work will introduce proper separation:
-
-- **[backlog#384](https://github.com/openmcp-project/backlog/issues/384)**: Discoverability of Open Control Plane components
-- **TenantPolicy/ServiceOffering**: Concept for tenant constraints and service offerings (tbd)
-
-Until these systems are available, Service Providers may need to include these concerns in their `ProviderConfig`. See the [Developer Guide](./02-service-providers.mdx#understanding-providerconfig) for practical guidelines on structuring your `ProviderConfig`.
-:::
-
 ### Service Discovery and Access Management
 
 End users need to be aware of a) the available managed services, and b) valid input values to consume a service offering.
 
 A) The available service offerings are made visible by installing the `ServiceProviderAPI` on the `OnboardingCluster` (see [deployment model](#deployment-model)). This ensures that any platform tenant is aware of all available `ServiceProviderAPIs`. In other words, the platform does not hide its end-user-facing feature set, even if a user belongs to a tenant that cannot successfully consume a specific `ServiceProviderAPI`.
 
-B) Valid input values are communicated through a yet-to-be-defined 'Marketplace'-like API provided by a `PlatformService`. Note: This is still work in progress and outside the scope of this document.
+B) Valid input values are communicated through a yet-to-be-defined 'Marketplace'-like API provided by a `PlatformService` (more information with regard to [Discoverability of Open Control Plane components](https://github.com/openmcp-project/backlog/issues/384)). Note: This is still work in progress and outside the scope of this document.
 
 ### Deployment Model
 

--- a/docs/developers/serviceprovider/04-design.mdx
+++ b/docs/developers/serviceprovider/04-design.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Design
 
 This document outlines the `ServiceProvider` domain and its technical considerations within the context of the [OpenControlPlane project](https://github.com/openmcp-project/), providing a foundation for understanding its architecture and operational aspects.

--- a/docs/developers/serviceprovider/design.md
+++ b/docs/developers/serviceprovider/design.md
@@ -147,7 +147,7 @@ ProviderConfig should **only** contain **controller operational configuration** 
 | **Reconciliation Behavior**    | How the controller reconciles resources    | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter`   |
 | **Retry & Timeouts**           | Controller retry and timeout configuration | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout`    |
 | **Observability Settings**     | Controller metrics, logging, and tracing   | `enableMetrics`, `metricsPort`, `logLevel`, `enableTracing` |
-| **Controller Feature Toggles** | Enable/disable controller-level features   | `enableDriftDetection`,                                     |
+| **Controller Feature Toggles** | Enable/disable controller-level features   | `enableDriftDetection`                                   |
 
 ##### What SHOULD NOT be in ProviderConfig
 

--- a/docs/developers/serviceprovider/design.md
+++ b/docs/developers/serviceprovider/design.md
@@ -147,7 +147,7 @@ ProviderConfig should **only** contain **controller operational configuration** 
 | **Reconciliation Behavior**    | How the controller reconciles resources    | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter`   |
 | **Retry & Timeouts**           | Controller retry and timeout configuration | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout`    |
 | **Observability Settings**     | Controller metrics, logging, and tracing   | `enableMetrics`, `metricsPort`, `logLevel`, `enableTracing` |
-| **Controller Feature Toggles** | Enable/disable controller-level features   | `enableDriftDetection`                                   |
+| **Controller Feature Toggles** | Enable/disable controller-level features   | `enableDriftDetection`                                      |
 
 ##### What SHOULD NOT be in ProviderConfig
 
@@ -157,16 +157,16 @@ The current `ProviderConfig` implementations across the project mix controller o
 
 The following information does **NOT** belong in ProviderConfig:
 
-| Category                                                                                    | Why It Doesn't Belong                                                       | Where It Should Live                            | Current State                                    |
-| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
-| **Deployment Artifacts**                                                                    | Controller doesn't need to know about images/charts — just how to reconcile | Future **Registry/ComponentCatalog** API        | Currently embedded in ProviderConfig (incorrect) |
-| - Image URLs                                                                                | Artifact location is deployment concern, not controller behavior            | Registry                                        | `availableImages`, `versions[].image.url`        |
-| - Chart URLs                                                                                | Same as image URLs                                                          | Registry                                        | `chartUrl`, `versions[].chart.url`               |
-| - Available Versions                                                                        | Not controller behavior                            | Registry + TenantPolicy/ServiceOffering         | Explicit version lists                           |
-| **Tenant Constraints**                                                                      | What tenants can or cannot use — not controller operational behavior        | Future **TenantPolicy/ServiceOffering** concept | Currently embedded in ProviderConfig (incorrect) |
+| Category                                                                                         | Why It Doesn't Belong                                                       | Where It Should Live                            | Current State                                    |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| **Deployment Artifacts**                                                                         | Controller doesn't need to know about images/charts — just how to reconcile | Future **Registry/ComponentCatalog** API        | Currently embedded in ProviderConfig (incorrect) |
+| - Image URLs                                                                                     | Artifact location is deployment concern, not controller behavior            | Registry                                        | `availableImages`, `versions[].image.url`        |
+| - Chart URLs                                                                                     | Same as image URLs                                                          | Registry                                        | `chartUrl`, `versions[].chart.url`               |
+| - Available Versions                                                                             | Not controller behavior                                                     | Registry + TenantPolicy/ServiceOffering         | Explicit version lists                           |
+| **Tenant Constraints**                                                                           | What tenants can or cannot use — not controller operational behavior        | Future **TenantPolicy/ServiceOffering** concept | Currently embedded in ProviderConfig (incorrect) |
 | - Allowed domain service specific extensions such as Crossplane Providers or Velero Plugins etc. | Tenant domain constraint, not controller setting                            | TenantPolicy/ServiceOffering                    | `allowedProviders`                               |
-| - Version Constraints                                                                       | Business policy, not controller behavior                                    | TenantPolicy/ServiceOffering                    | `minVersion`, `maxVersion`, `versionPolicy`      |
-| - Feature Access Control                                                                    | Domain-level tenant restrictions                                            | TenantPolicy/ServiceOffering                    | Various feature flags                            |
+| - Version Constraints                                                                            | Business policy, not controller behavior                                    | TenantPolicy/ServiceOffering                    | `minVersion`, `maxVersion`, `versionPolicy`      |
+| - Feature Access Control                                                                         | Domain-level tenant restrictions                                            | TenantPolicy/ServiceOffering                    | Various feature flags                            |
 
 ##### Design Implications
 

--- a/docs/developers/serviceprovider/design.md
+++ b/docs/developers/serviceprovider/design.md
@@ -74,7 +74,47 @@ sequenceDiagram
 
 ### Config
 
-A `ServiceProvider` defines a `ServiceProviderConfig` that contains provider-specific options for platform operators to specify a managed service offering. For example, [service-provider-crossplane](https://github.com/openmcp-project/service-provider-crossplane/) allows platform operators to decide which Crossplane providers can be installed by end user as part of the managed service.
+The configuration of a Service Provider involves two distinct resources that serve different purposes:
+
+#### ServiceProvider vs. ProviderConfig
+
+It is important to understand the separation between the `ServiceProvider` CRD and the `ProviderConfig` CRD:
+
+| Resource            | API Group                                   | Purpose                                                 | Managed By        |
+| ------------------- | ------------------------------------------- | ------------------------------------------------------- | ----------------- |
+| **ServiceProvider** | `openmcp.cloud/v1alpha1`                    | How to deploy the ServiceProvider controller itself     | openmcp-operator  |
+| **ProviderConfig**  | `<service>.services.openmcp.cloud/v1alpha1` | How the deployed controller should behave operationally | Platform Operator |
+
+**ServiceProvider** (managed by openmcp-operator) defines the controller deployment:
+
+```yaml
+apiVersion: openmcp.cloud/v1alpha1
+kind: ServiceProvider
+metadata:
+  name: external-secrets
+spec:
+  # Controller image to deploy
+  image: .../service-provider-external-secrets:v0.1.0@sha256:...
+  # Secrets for pulling the CONTROLLER image
+  imagePullSecrets:
+    - name: artifactory
+  # Controller replicas
+  runReplicas: 1
+  # Controller log verbosity
+  verbosity: debug
+```
+
+**ProviderConfig** (managed by Platform Operator) defines controller operational behavior:
+
+```yaml
+apiVersion: externalsecrets.services.openmcp.cloud/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  # How the controller reconciles
+  pollInterval: 1m
+```
 
 ```mermaid
 graph LR
@@ -82,7 +122,7 @@ graph LR
     OP[PlatformOperator]
     SP[ServiceProvider]
     SPA[ServiceProviderAPI]
-    SPC[ServiceProviderConfig]
+    SPC[ProviderConfig]
     OP -->|manages instances|SP
     OP -->|manages instances|SPC
     OP -. installs .-> SPA
@@ -91,8 +131,116 @@ graph LR
 All operator tasks may be partially or fully automated.
 
 :::info
-The `ServiceProvider` object itself is a higher level platform concept that is described in the corresponding `PlatformService`, i.e. [openmcp-operator](https://github.com/openmcp-project/openmcp-operator).
+The `ServiceProvider` object itself is a higher level platform concept that is described in the corresponding `PlatformService`, i.e. [openmcp-operator](https://github.com/openmcp-project/openmcp-operator). The `ServiceProvider` handles deployment concerns (image, replicas, pull secrets for the controller), while `ProviderConfig` handles runtime operational concerns (poll intervals, timeouts, controller features).
 :::
+
+#### ServiceProviderConfig Guidelines
+
+When designing a `ProviderConfig` for your Service Provider, follow these guidelines to ensure consistency and maintainability across the platform.
+
+##### What SHOULD be in ProviderConfig
+
+ProviderConfig should **only** contain **controller operational configuration** — settings that control how the ServiceProvider controller behaves, not what it deploys or what users/tenants can use.
+
+| Category                       | Description                                | Examples                                                    |
+| ------------------------------ | ------------------------------------------ | ----------------------------------------------------------- |
+| **Reconciliation Behavior**    | How the controller reconciles resources    | `pollInterval`, `maxConcurrentReconciles`, `requeueAfter`   |
+| **Retry & Timeouts**           | Controller retry and timeout configuration | `retryBackoff`, `reconcileTimeout`, `helmReleaseTimeout`    |
+| **Observability Settings**     | Controller metrics, logging, and tracing   | `enableMetrics`, `metricsPort`, `logLevel`, `enableTracing` |
+| **Controller Feature Toggles** | Enable/disable controller-level features   | `enableDriftDetection`,                                     |
+
+##### What SHOULD NOT be in ProviderConfig
+
+:::warning Current State vs. Pure Design
+The current `ProviderConfig` implementations across the project mix controller operational configuration with deployment artifacts and tenant constraints. This section clarifies what does NOT belong in ProviderConfig and where it should live instead. Future work tracked in [backlog#384](https://github.com/openmcp-project/backlog/issues/384) will introduce proper separation of concerns.
+:::
+
+The following information does **NOT** belong in ProviderConfig:
+
+| Category                                                                                    | Why It Doesn't Belong                                                       | Where It Should Live                            | Current State                                    |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| **Deployment Artifacts**                                                                    | Controller doesn't need to know about images/charts — just how to reconcile | Future **Registry/ComponentCatalog** API        | Currently embedded in ProviderConfig (incorrect) |
+| - Image URLs                                                                                | Artifact location is deployment concern, not controller behavior            | Registry                                        | `availableImages`, `versions[].image.url`        |
+| - Chart URLs                                                                                | Same as image URLs                                                          | Registry                                        | `chartUrl`, `versions[].chart.url`               |
+| - Available Versions                                                                        | Not controller behavior                            | Registry + TenantPolicy/ServiceOffering         | Explicit version lists                           |
+| **Tenant Constraints**                                                                      | What tenants can or cannot use — not controller operational behavior        | Future **TenantPolicy/ServiceOffering** concept | Currently embedded in ProviderConfig (incorrect) |
+| - Allowed domain service specific extensions such as Crossplane Providers or Velero Plugins etc. | Tenant domain constraint, not controller setting                            | TenantPolicy/ServiceOffering                    | `allowedProviders`                               |
+| - Version Constraints                                                                       | Business policy, not controller behavior                                    | TenantPolicy/ServiceOffering                    | `minVersion`, `maxVersion`, `versionPolicy`      |
+| - Feature Access Control                                                                    | Domain-level tenant restrictions                                            | TenantPolicy/ServiceOffering                    | Various feature flags                            |
+
+##### Design Implications
+
+1. **For Service Provider Contributors**: When creating a new Service Provider today, you will need to temporarily include deployment artifacts (images, charts, versions) and potentially tenant constraints in your `ProviderConfig`. This is a known limitation. Structure your API so these fields can be gracefully deprecated when the Registry API and TenantPolicy/ServiceOffering concepts become available. Clearly document which fields are operational (permanent) vs. artifacts/constraints (temporary).
+
+2. **For Platform Operators**: Current `ProviderConfig` resources mix operational settings with deployment artifacts and tenant constraints. The operational settings (pollInterval, timeouts, retries) configure controller behavior and will remain. The artifacts and constraints will eventually move to separate systems.
+
+3. **For Version Updates**: Adding support for a new service version currently requires updating the `ProviderConfig`. In the future, the Registry will handle artifact discovery, and TenantPolicy/ServiceOffering will handle what tenants can use.
+
+##### Example: Current vs. Pure ProviderConfig
+
+**Current State** (mixed concerns — deployment artifacts + tenant constraints + operational config):
+
+```yaml
+apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  # OPERATIONAL (correct — belongs here)
+  pollInterval: 1m
+  maxConcurrentReconciles: 5
+  helmReleaseTimeout: 10m
+
+  # DEPLOYMENT ARTIFACTS (incorrect — should live in Registry)
+  versions:
+    - version: "1.18.0"
+      chart:
+        url: oci://ghcr.io/crossplane/crossplane
+        secretRef:
+          name: registry-credentials
+      image:
+        url: crossplane/crossplane:v1.18.0
+        secretRef:
+          name: registry-credentials
+
+  # TENANT CONSTRAINTS (incorrect — should live in TenantPolicy/ServiceOffering)
+  providers:
+    allowedProviders:
+      - provider-kubernetes
+      - provider-helm
+```
+
+**Future State** (pure operational configuration only):
+
+```yaml
+apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  # Controller operational settings only
+  pollInterval: 1m
+  maxConcurrentReconciles: 5
+  helmReleaseTimeout: 10m
+  retryBackoff:
+    initialInterval: 5s
+    maxInterval: 5m
+  enableMetrics: true
+  logLevel: info
+```
+
+**Deployment artifacts** move to separate API (backlog#384):
+
+tbd
+
+**Tenant constraints** move to TenantPolicy/ServiceOffering concept:
+
+tbd
+
+##### Related Issues and Future Work
+
+- [backlog#384: Discoverability of Open Control Plane components](https://github.com/openmcp-project/backlog/issues/384) — Will introduce Registry API for deployment artifacts
+- Future TenantPolicy/ServiceOffering concept — Will separate tenant constraints from controller configuration
 
 ### Service Discovery and Access Management
 
@@ -181,12 +329,12 @@ The `service-provider-runtime` is built on top of `controller-runtime` and intro
 
 The following table provides a simplified overview of the layers within a `ServiceProvider` controller:
 
-| Layer | Description | Target Audience |
-| :--- | :--- | :--- |
-| Service Provider | Defines `ServiceProviderAPI`/`ServiceProviderConfig` and implements service-provider-runtime operations | Service provider developers |
-| service-provider-runtime | Defines ServiceProvider reconciliation semantics | Platform developers |
-| multicluster/controller-runtime | Defines generic reconciliation semantics | Out of scope |
-| Kubernetes API machinery | Kubernetes essentials | Out of scope |
+| Layer                           | Description                                                                                             | Target Audience             |
+| :------------------------------ | :------------------------------------------------------------------------------------------------------ | :-------------------------- |
+| Service Provider                | Defines `ServiceProviderAPI`/`ServiceProviderConfig` and implements service-provider-runtime operations | Service provider developers |
+| service-provider-runtime        | Defines ServiceProvider reconciliation semantics                                                        | Platform developers         |
+| multicluster/controller-runtime | Defines generic reconciliation semantics                                                                | Out of scope                |
+| Kubernetes API machinery        | Kubernetes essentials                                                                                   | Out of scope                |
 
 ### Functionality
 


### PR DESCRIPTION
## Summary

- Add ProviderConfig guidelines to the ServiceProvider developer guide
- Clarify the separation between `ServiceProvider` (deployment) and `ProviderConfig` (operational behavior) in design docs
- Fix broken cross-references between provider design documentation files

## Context

Addresses both sub-issues of openmcp-project/backlog#517:
- **openmcp-project/docs#48**: Document ProviderConfig guidelines in design docs
- **openmcp-project/docs#36**: Document current state of ProviderConfig in development guide

## Changes

### Developer Guide (`02-service-providers.mdx`)
- New "ProviderConfig Guidelines" section explaining what should/shouldn't be in ProviderConfig
- Info box about temporary necessity of deployment artifacts until Registry/TenantPolicy systems exist
- **Ideal Minimal ProviderConfig** example showing clean operational-only structure
- Updated Velero example with annotations distinguishing operational settings from temporary deployment artifacts

### Design Documentation (`design.md` → `04-design.mdx`)
- Renamed file and added Docusaurus frontmatter for proper sidebar positioning
- Clarified that `ProviderConfig` handles runtime operational concerns while `ServiceProvider` handles deployment concerns
- Updated Config section to explain ProviderConfig purpose more precisely
- Added reference to backlog#384 (future Registry API) in Service Discovery section
- Fixed markdown table formatting

### Cross-Reference Fixes
- Updated `clusterprovider/04-design.mdx` and `platformprovider/05-design.mdx` to reference the renamed file

## Related Issues

- Closes openmcp-project/docs#48
- Closes openmcp-project/docs#36
- Part of openmcp-project/backlog#517
- References openmcp-project/backlog#384 (future Registry API)