### PR TITLE
chore: add Taskfile with Docker tasks and document them in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ $ npm start
 
 The local development server should start and open up a browser window. Most changes are reflected live without having to restart the server or reload the website.
 
+### 🐳 Docker
+
+If you prefer not to install Node.js locally, you can use the provided [Taskfile](Taskfile.yml) with [Task](https://taskfile.dev) to run the project in Docker.
+
+| Task                | Description                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `task docker-dev`   | Run the dev server with live reload at `http://localhost:3000`    |
+| `task docker-serve` | Build the production site and serve it at `http://localhost:3000` |
+
 Changes to the documentation must be done via pull requests. A GitHub Actions [workflow](.github/workflows/test-deploy.yml) will check if the website can be built.
 
 ### 🌍 Deployment

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,26 @@
+version: "3"
+
+tasks:
+  docker-dev:
+    desc: Run the Docusaurus dev server in Docker with live reload
+    cmds:
+      - |
+        docker run --rm -it \
+          -v "$(pwd):/workspace" \
+          -w /workspace \
+          -p 3000:3000 \
+          --user node \
+          node:25-alpine \
+          sh -c "npm ci && npm start -- --host 0.0.0.0"
+
+  docker-serve:
+    desc: Build and serve the production Docusaurus site in Docker
+    cmds:
+      - |
+        docker run --rm -it \
+          -v "$(pwd):/workspace" \
+          -w /workspace \
+          -p 3000:3000 \
+          --user node \
+          node:25-alpine \
+          sh -c "npm ci && npm run build && npm run serve -- --host 0.0.0.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `Taskfile.yml` with two Docker-based tasks for running the Docusaurus project locally without requiring a local Node.js installation:

- `task docker-dev` — starts the dev server with live reload at `http://localhost:3000`
- `task docker-serve` — builds the production site and serves it at `http://localhost:3000`

Also adds a Docker section to the README documenting these tasks.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Requires [Task](https://taskfile.dev) to be installed locally to use the `task` commands. Docker must also be available.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add Taskfile with Docker tasks for running Docusaurus locally without a local Node.js installation.
```