### PR TITLE
docs(sp-dev-guide): prefix secrets in tenant namespaces

### DIFF
--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -673,6 +673,11 @@ func createHelmRelease() (*helmv2.HelmRelease, error) {
 In here, the values, for example, could come from the `ProviderConfig`. Or further image accesses could be configured by other service accounts and secrets
 being created as a first step.
 
+:::warning
+If secrets need to be copied into tenant namespaces on the platform cluster (e.g. to access an OCIRepository with a Helm chart), the secret name must be adjusted to avoid conflicts with other service providers.
+Use a service‑provider–specific prefix for the copied secret, e.g. rename privateregcred to sp-crossplane-privateregcred. Make sure the resulting name does not exceed the allowed [max name length](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+:::
+
 Also notice the `KubeConfig` section. Your service provider controller is deployed in the Platform cluster. The target controller that your provider is deploying
 will run in either the MCP or the Workload cluster. This depends on your choice, however, it is recommended to deploy into the workload cluster as documented [here](https://openmcp-project.github.io/docs/about/design/service-provider/#non-goals).
 


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Document requirement to prefix secrets that are copied into (shared) tenant namespaces on the platform cluster when using Flux.

**Which issue(s) this PR fixes**:
Part of https://github.com/openmcp-project/backlog/issues/557

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```