### PR TITLE
chore: add id to stabilize shared links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,27 @@
 # CLAUDE.md — Project guidelines for Claude Code
 
-## Slug requirement
+## Document ID requirement
 
-Every documentation page (`.md` / `.mdx` in `docs/`) **must** have an explicit `slug:` in its frontmatter.
+Every documentation page (`.md` / `.mdx` in `docs/`) **must** have an explicit `id:` in its frontmatter.
 
-Slugs must:
-- Start with `/` and mirror the logical URL path (e.g. `/operators/setup`)
-- Strip numeric filename prefixes (e.g. `01-setup.md` → `/operators/setup`)
+The `id:` field sets the document identifier, which Docusaurus uses to generate the URL. This keeps URLs tied to the folder structure while stripping numeric prefixes from filenames.
+
+IDs must:
+- Be the desired URL segment (without path prefix)
+- Strip numeric filename prefixes (e.g. `01-setup.md` → `id: setup`)
 - Use kebab-case
 
 Example:
 ```md
 ---
 sidebar_position: 1
-slug: /operators/setup
+id: setup
 ---
 ```
 
-Pages without a `slug:` field will produce non-deterministic URLs if files are renamed or reordered — always add one when creating or renaming a page.
+The resulting URL will be `/operators/setup` (folder path + id).
+
+Pages without an `id:` field will use the filename as-is, including any numeric prefixes — always add one when creating or renaming a page.
 
 ## Branch workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,4 +31,3 @@ Work on feature branches based on `main`. Merge via PR.
 
 - Docusaurus 3 (MDX + React in `.mdx` files)
 - Custom CSS variables in `src/css/custom.css`
-- Brand teal palette: `--teal-2` through `--teal-11` (see `docs/developers/branding.mdx`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md — Project guidelines for Claude Code
+
+## Slug requirement
+
+Every documentation page (`.md` / `.mdx` in `docs/`) **must** have an explicit `slug:` in its frontmatter.
+
+Slugs must:
+- Start with `/` and mirror the logical URL path (e.g. `/operators/setup`)
+- Strip numeric filename prefixes (e.g. `01-setup.md` → `/operators/setup`)
+- Use kebab-case
+
+Example:
+```md
+---
+sidebar_position: 1
+slug: /operators/setup
+---
+```
+
+Pages without a `slug:` field will produce non-deterministic URLs if files are renamed or reordered — always add one when creating or renaming a page.
+
+## Branch workflow
+
+Work on feature branches based on `main`. Merge via PR.
+
+## Stack
+
+- Docusaurus 3 (MDX + React in `.mdx` files)
+- Custom CSS variables in `src/css/custom.css`
+- Brand teal palette: `--teal-2` through `--teal-11` (see `docs/developers/branding.mdx`)

--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /community/overview
+id: overview
 ---
 
 import IconContainer from '@site/src/components/IconContainer';

--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /community/overview
 ---
 
 import IconContainer from '@site/src/components/IconContainer';

--- a/docs/developers/00-getting-started.mdx
+++ b/docs/developers/00-getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 0
+slug: /developers/getting-started
 ---
 
 import IconContainer from '@site/src/components/IconContainer';

--- a/docs/developers/00-getting-started.mdx
+++ b/docs/developers/00-getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 0
-slug: /developers/getting-started
+id: getting-started
 ---
 
 import IconContainer from '@site/src/components/IconContainer';

--- a/docs/developers/00-getting-started.mdx
+++ b/docs/developers/00-getting-started.mdx
@@ -14,7 +14,7 @@ Whether you're a beginner or an experienced developer, this guide will help you 
 
 ## Getting Started
 
-Check our guide on [how to create a Service Provider](./serviceprovider/service-providers) to turn the next Kubernetes-native application into an as-a-Service offering.
+Check our guide on [how to create a Service Provider](./serviceprovider/develop) to turn the next Kubernetes-native application into an as-a-Service offering.
 
 ## Join the Community
 

--- a/docs/developers/clusterprovider/01-deployment.mdx
+++ b/docs/developers/clusterprovider/01-deployment.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /developers/clusterprovider/deploy
 ---
 
 # Deploy

--- a/docs/developers/clusterprovider/01-deployment.mdx
+++ b/docs/developers/clusterprovider/01-deployment.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /developers/clusterprovider/deploy
+id: deploy
 ---
 
 # Deploy

--- a/docs/developers/clusterprovider/02-develop.mdx
+++ b/docs/developers/clusterprovider/02-develop.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /developers/clusterprovider/develop
+id: develop
 ---
 
 # Develop

--- a/docs/developers/clusterprovider/02-develop.mdx
+++ b/docs/developers/clusterprovider/02-develop.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /developers/clusterprovider/develop
 ---
 
 # Develop

--- a/docs/developers/clusterprovider/02-develop.mdx
+++ b/docs/developers/clusterprovider/02-develop.mdx
@@ -14,7 +14,7 @@ Cluster Providers manage Kubernetes clusters and provide access to them within t
 For now, you can:
 - Review existing implementations: [cluster-provider-gardener](https://github.com/openmcp-project/cluster-provider-gardener) and [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind)
 - Refer to the [Deploy Guide](./01-deployment.mdx) for the common deployment contract
-- Check the [Service Provider Develop Guide](../serviceprovider/02-service-providers.mdx) for general patterns that apply to all provider types
+- Check the [Service Provider Develop Guide](../serviceprovider/02-develop.mdx) for general patterns that apply to all provider types
 
 ## Implementing a ClusterProvider
 

--- a/docs/developers/clusterprovider/03-examples.mdx
+++ b/docs/developers/clusterprovider/03-examples.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /developers/clusterprovider/examples
+id: examples
 ---
 
 # Examples

--- a/docs/developers/clusterprovider/03-examples.mdx
+++ b/docs/developers/clusterprovider/03-examples.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /developers/clusterprovider/examples
 ---
 
 # Examples

--- a/docs/developers/clusterprovider/04-design.mdx
+++ b/docs/developers/clusterprovider/04-design.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-slug: /developers/clusterprovider/design
+id: design
 ---
 
 # Design

--- a/docs/developers/clusterprovider/04-design.mdx
+++ b/docs/developers/clusterprovider/04-design.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+slug: /developers/clusterprovider/design
 ---
 
 # Design

--- a/docs/developers/general.mdx
+++ b/docs/developers/general.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /developers/general
+id: general
 ---
 
 # General Controller Guidelines

--- a/docs/developers/general.mdx
+++ b/docs/developers/general.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /developers/general
 ---
 
 # General Controller Guidelines

--- a/docs/developers/platformprovider/01-deployment.mdx
+++ b/docs/developers/platformprovider/01-deployment.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /developers/platformprovider/deploy
+id: deploy
 ---
 
 # Deploy

--- a/docs/developers/platformprovider/01-deployment.mdx
+++ b/docs/developers/platformprovider/01-deployment.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /developers/platformprovider/deploy
 ---
 
 # Deploy

--- a/docs/developers/platformprovider/03-develop.mdx
+++ b/docs/developers/platformprovider/03-develop.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /developers/platformprovider/develop
 ---
 
 # Develop

--- a/docs/developers/platformprovider/03-develop.mdx
+++ b/docs/developers/platformprovider/03-develop.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /developers/platformprovider/develop
+id: develop
 ---
 
 # Develop

--- a/docs/developers/platformprovider/03-develop.mdx
+++ b/docs/developers/platformprovider/03-develop.mdx
@@ -13,4 +13,4 @@ Platform Providers deliver complete platform capabilities and services within th
 
 For now, you can:
 - Refer to the [Deploy Guide](./01-deployment.mdx) for the common deployment contract
-- Check the [Service Provider Develop Guide](../serviceprovider/02-service-providers.mdx) for general patterns that apply to all provider types
+- Check the [Service Provider Develop Guide](../serviceprovider/02-develop.mdx) for general patterns that apply to all provider types

--- a/docs/developers/platformprovider/04-examples.mdx
+++ b/docs/developers/platformprovider/04-examples.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+slug: /developers/platformprovider/examples
 ---
 
 # Examples

--- a/docs/developers/platformprovider/04-examples.mdx
+++ b/docs/developers/platformprovider/04-examples.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-slug: /developers/platformprovider/examples
+id: examples
 ---
 
 # Examples

--- a/docs/developers/platformprovider/05-design.mdx
+++ b/docs/developers/platformprovider/05-design.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+slug: /developers/platformprovider/design
 ---
 
 # Design

--- a/docs/developers/platformprovider/05-design.mdx
+++ b/docs/developers/platformprovider/05-design.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-slug: /developers/platformprovider/design
+id: design
 ---
 
 # Design

--- a/docs/developers/serviceprovider/01-deployment.mdx
+++ b/docs/developers/serviceprovider/01-deployment.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /developers/serviceprovider/deploy
 ---
 
 # Deploy

--- a/docs/developers/serviceprovider/01-deployment.mdx
+++ b/docs/developers/serviceprovider/01-deployment.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /developers/serviceprovider/deploy
+id: deploy
 ---
 
 # Deploy

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -1,4 +1,5 @@
 ---
+sidebar_position: 2
 id: develop
 ---
 

--- a/docs/developers/serviceprovider/02-service-providers.mdx
+++ b/docs/developers/serviceprovider/02-service-providers.mdx
@@ -1,3 +1,7 @@
+---
+slug: /developers/serviceprovider/develop
+---
+
 # Develop
 
 This guide shows you how to create Service Provider for the OpenControlPlane ecosystem from scratch. Service Providers are the heart of the OpenControlPlane platform, as they provide the capabilities to offer Infrastructure as Data services to end users.

--- a/docs/developers/serviceprovider/02-service-providers.mdx
+++ b/docs/developers/serviceprovider/02-service-providers.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /developers/serviceprovider/develop
+id: develop
 ---
 
 # Develop

--- a/docs/developers/serviceprovider/03-examples.mdx
+++ b/docs/developers/serviceprovider/03-examples.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /developers/serviceprovider/examples
+id: examples
 ---
 
 # Examples

--- a/docs/developers/serviceprovider/03-examples.mdx
+++ b/docs/developers/serviceprovider/03-examples.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /developers/serviceprovider/examples
 ---
 
 # Examples

--- a/docs/developers/serviceprovider/04-design.mdx
+++ b/docs/developers/serviceprovider/04-design.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-slug: /developers/serviceprovider/design
+id: design
 ---
 
 # Design

--- a/docs/developers/serviceprovider/04-design.mdx
+++ b/docs/developers/serviceprovider/04-design.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+slug: /developers/serviceprovider/design
 ---
 
 # Design

--- a/docs/operators/00-overview.md
+++ b/docs/operators/00-overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 0
-slug: /operators/overview
+id: overview
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/00-overview.md
+++ b/docs/operators/00-overview.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 0
+slug: /operators/overview
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/01-setup.md
+++ b/docs/operators/01-setup.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 0
+slug: /operators/setup
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/01-setup.md
+++ b/docs/operators/01-setup.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 slug: /operators/setup
 ---
 

--- a/docs/operators/01-setup.md
+++ b/docs/operators/01-setup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /operators/setup
+id: setup
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/02-gardener-provider.md
+++ b/docs/operators/02-gardener-provider.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /operators/gardener-provider
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/02-gardener-provider.md
+++ b/docs/operators/02-gardener-provider.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /operators/gardener-provider
+id: gardener-provider
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/03-kind-provider.md
+++ b/docs/operators/03-kind-provider.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /operators/kind-provider
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/03-kind-provider.md
+++ b/docs/operators/03-kind-provider.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /operators/kind-provider
+id: kind-provider
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/04-verify-setup.md
+++ b/docs/operators/04-verify-setup.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /operators/verify-setup
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/04-verify-setup.md
+++ b/docs/operators/04-verify-setup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /operators/verify-setup
+id: verify-setup
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/how-to-guides/01-custom-ca.md
+++ b/docs/operators/how-to-guides/01-custom-ca.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /operators/how-to-guides/custom-ca
+id: custom-ca
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/operators/how-to-guides/01-custom-ca.md
+++ b/docs/operators/how-to-guides/01-custom-ca.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /operators/how-to-guides/custom-ca
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/reference/00-overview.md
+++ b/docs/reference/00-overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /reference/overview
+id: overview
 ---
 
 # CRD Reference

--- a/docs/reference/00-overview.md
+++ b/docs/reference/00-overview.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /reference/overview
 ---
 
 # CRD Reference

--- a/docs/reference/core/managedcontrolplane.md
+++ b/docs/reference/core/managedcontrolplane.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /reference/core/managedcontrolplane
+id: managedcontrolplane
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/core/managedcontrolplane.md
+++ b/docs/reference/core/managedcontrolplane.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /reference/core/managedcontrolplane
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/core/project.md
+++ b/docs/reference/core/project.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /reference/core/project
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/core/project.md
+++ b/docs/reference/core/project.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /reference/core/project
+id: project
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/core/workspace.md
+++ b/docs/reference/core/workspace.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /reference/core/workspace
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/core/workspace.md
+++ b/docs/reference/core/workspace.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /reference/core/workspace
+id: workspace
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/accessrequest.md
+++ b/docs/reference/operator/clusters/accessrequest.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /reference/operator/clusters/accessrequest
+id: accessrequest
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/accessrequest.md
+++ b/docs/reference/operator/clusters/accessrequest.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /reference/operator/clusters/accessrequest
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/cluster.md
+++ b/docs/reference/operator/clusters/cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /reference/operator/clusters/cluster
+id: cluster
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/cluster.md
+++ b/docs/reference/operator/clusters/cluster.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /reference/operator/clusters/cluster
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/clusterprofile.md
+++ b/docs/reference/operator/clusters/clusterprofile.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+slug: /reference/operator/clusters/clusterprofile
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/clusterprofile.md
+++ b/docs/reference/operator/clusters/clusterprofile.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-slug: /reference/operator/clusters/clusterprofile
+id: clusterprofile
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/clusterrequest.md
+++ b/docs/reference/operator/clusters/clusterrequest.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /reference/operator/clusters/clusterrequest
+id: clusterrequest
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/clusters/clusterrequest.md
+++ b/docs/reference/operator/clusters/clusterrequest.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /reference/operator/clusters/clusterrequest
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/providers/clusterprovider.md
+++ b/docs/reference/operator/providers/clusterprovider.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /reference/operator/providers/clusterprovider
+id: clusterprovider
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/providers/clusterprovider.md
+++ b/docs/reference/operator/providers/clusterprovider.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /reference/operator/providers/clusterprovider
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/providers/platformservice.md
+++ b/docs/reference/operator/providers/platformservice.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /reference/operator/providers/platformservice
+id: platformservice
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/providers/platformservice.md
+++ b/docs/reference/operator/providers/platformservice.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /reference/operator/providers/platformservice
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/providers/serviceprovider.md
+++ b/docs/reference/operator/providers/serviceprovider.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /reference/operator/providers/serviceprovider
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/operator/providers/serviceprovider.md
+++ b/docs/reference/operator/providers/serviceprovider.md
@@ -27,5 +27,5 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 
 ## Related Resources
 
-- [Build a Service Provider](/developers/serviceprovider/service-providers)
+- [Build a Service Provider](/developers/serviceprovider/develop)
 - [Service Provider Examples](/developers/serviceprovider/examples)

--- a/docs/reference/operator/providers/serviceprovider.md
+++ b/docs/reference/operator/providers/serviceprovider.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /reference/operator/providers/serviceprovider
+id: serviceprovider
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/crossplane.md
+++ b/docs/reference/services/crossplane.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /reference/services/crossplane
+id: crossplane
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/crossplane.md
+++ b/docs/reference/services/crossplane.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /reference/services/crossplane
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/landscaper.md
+++ b/docs/reference/services/landscaper.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /reference/services/landscaper
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/landscaper.md
+++ b/docs/reference/services/landscaper.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /reference/services/landscaper
+id: landscaper
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/ocm.md
+++ b/docs/reference/services/ocm.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-slug: /reference/services/ocm
+id: ocm
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/ocm.md
+++ b/docs/reference/services/ocm.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+slug: /reference/services/ocm
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/velero.md
+++ b/docs/reference/services/velero.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /reference/services/velero
+id: velero
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/reference/services/velero.md
+++ b/docs/reference/services/velero.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /reference/services/velero
 ---
 
 import CRDViewerCompact from '@site/src/components/CRDViewerCompact';

--- a/docs/users/00-getting-started.md
+++ b/docs/users/00-getting-started.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 0
-slug: /users/getting-started
+id: getting-started
 ---
 
 # Welcome

--- a/docs/users/00-getting-started.md
+++ b/docs/users/00-getting-started.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 0
+slug: /users/getting-started
 ---
 
 # Welcome

--- a/docs/users/concepts/cluster-provider.md
+++ b/docs/users/concepts/cluster-provider.md
@@ -1,3 +1,7 @@
+---
+slug: /users/concepts/cluster-provider
+---
+
 # Cluster Providers
 
 Cluster providers are responsible for the dynamic creation, modification, and deletion of Kubernetes clusters in an OpenControlPlane environment. They conceal certain cluster technologies (e.g., [Gardener](https://gardener.cloud/) and [Kubernetes-in-Docker](https://kind.sigs.k8s.io/)) behind a homogeneous interface. This allows operators to install an OpenControlPlane system in different environments and on various infrastructure providers without having to adjust the other components of the system accordingly.

--- a/docs/users/concepts/cluster-provider.md
+++ b/docs/users/concepts/cluster-provider.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /users/concepts/cluster-provider
+id: cluster-provider
 ---
 
 # Cluster Providers

--- a/docs/users/concepts/cluster-provider.md
+++ b/docs/users/concepts/cluster-provider.md
@@ -1,4 +1,5 @@
 ---
+sidebar_position: 3
 slug: /users/concepts/cluster-provider
 ---
 

--- a/docs/users/concepts/managed-control-plane.md
+++ b/docs/users/concepts/managed-control-plane.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /users/concepts/managed-control-plane
+id: managed-control-plane
 ---
 
 # Managed Control Planes (MCPs)

--- a/docs/users/concepts/managed-control-plane.md
+++ b/docs/users/concepts/managed-control-plane.md
@@ -1,4 +1,5 @@
 ---
+sidebar_position: 1
 slug: /users/concepts/managed-control-plane
 ---
 

--- a/docs/users/concepts/managed-control-plane.md
+++ b/docs/users/concepts/managed-control-plane.md
@@ -1,3 +1,7 @@
+---
+slug: /users/concepts/managed-control-plane
+---
+
 # Managed Control Planes (MCPs)
 
 Managed Control Planes (MCPs) are at the heart of OpenControlPlane. Simply put, they are lightweight Kubernetes clusters that store the desired state and current status of various resources. All resources follow the Kubernetes Resource Model (KRM), allowing infrastructure resources, deployments, etc., to be managed with common Kubernetes tools like kubectl, kustomize, Helm, Flux, ArgoCD, and so on.

--- a/docs/users/concepts/platform-service.md
+++ b/docs/users/concepts/platform-service.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-slug: /users/concepts/platform-service
+id: platform-service
 ---
 
 # Platform Services

--- a/docs/users/concepts/platform-service.md
+++ b/docs/users/concepts/platform-service.md
@@ -1,3 +1,7 @@
+---
+slug: /users/concepts/platform-service
+---
+
 # Platform Services
 
 Platform services add functionality to an OpenControlPlane environment (not MCPs). Examples include network services (Gateway API, Ingress), audit logs, billing, grouping of MCPs, and system-wide policies. They are installed and configured by the platform operator and apply to the entire system.

--- a/docs/users/concepts/platform-service.md
+++ b/docs/users/concepts/platform-service.md
@@ -1,4 +1,5 @@
 ---
+sidebar_position: 4
 slug: /users/concepts/platform-service
 ---
 

--- a/docs/users/concepts/service-provider.md
+++ b/docs/users/concepts/service-provider.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /users/concepts/service-provider
+id: service-provider
 ---
 
 # Service Providers

--- a/docs/users/concepts/service-provider.md
+++ b/docs/users/concepts/service-provider.md
@@ -1,3 +1,7 @@
+---
+slug: /users/concepts/service-provider
+---
+
 # Service Providers
 
 Without service providers, MCPs are of little use. They add functionality such as cloud provider APIs, GitOps, policies, or backup and restore to MCPs. The operators of an OpenControlPlane environment decide which service providers are available to end users. The end users can then activate them for their MCPs.

--- a/docs/users/concepts/service-provider.md
+++ b/docs/users/concepts/service-provider.md
@@ -1,4 +1,5 @@
 ---
+sidebar_position: 2
 slug: /users/concepts/service-provider
 ---
 

--- a/docs/users/ecosystem.md
+++ b/docs/users/ecosystem.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /users/ecosystem
 ---
 
 # Ecosystem

--- a/docs/users/ecosystem.md
+++ b/docs/users/ecosystem.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /users/ecosystem
+id: ecosystem
 ---
 
 # Ecosystem

--- a/docs/users/getting-started/01-onboard.md
+++ b/docs/users/getting-started/01-onboard.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-slug: /users/getting-started/onboard
+id: onboard
 ---
 
 # 1. Onboard

--- a/docs/users/getting-started/01-onboard.md
+++ b/docs/users/getting-started/01-onboard.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /users/getting-started/onboard
 ---
 
 # 1. Onboard

--- a/docs/users/getting-started/02-connect.md
+++ b/docs/users/getting-started/02-connect.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-slug: /users/getting-started/connect
+id: connect
 ---
 
 # 2. Connect

--- a/docs/users/getting-started/02-connect.md
+++ b/docs/users/getting-started/02-connect.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+slug: /users/getting-started/connect
 ---
 
 # 2. Connect

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-slug: /users/getting-started/configure
+id: configure
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+slug: /users/getting-started/configure
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,6 +72,20 @@ const config: Config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            from: '/developers/serviceprovider/service-providers',
+            to: '/developers/serviceprovider/develop',
+          },
+        ],
+      },
+    ],
+  ],
+
   themeConfig: {
     // Replace with your project's social card
     image: 'img/co_axolotl.png',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.8.1",
+        "@docusaurus/plugin-client-redirects": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
         "@docusaurus/theme-mermaid": "^3.8.1",
         "@mdx-js/react": "^3.0.0",
@@ -3443,6 +3444,30 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.1.tgz",
+      "integrity": "sha512-F+86R7PBn6VNgy/Ux8w3ZRypJGJEzksbejQKlbTC8u6uhBUhfdXWkDp6qdOisIoW0buY5nLqucvZt1zNJzhJhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@docusaurus/plugin-content-blog": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
@@ -4871,15 +4896,15 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
-      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
@@ -6522,16 +6547,16 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
-      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
         "negotiator": "~0.6.4",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
@@ -8603,39 +8628,39 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -8680,6 +8705,21 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/express/node_modules/range-parser": {
       "version": "1.2.1",
@@ -13227,9 +13267,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -13575,9 +13615,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15830,9 +15870,9 @@
       }
     },
     "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3"
@@ -16729,15 +16769,15 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
-      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "mime-types": "2.1.18",
-        "minimatch": "3.1.2",
+        "minimatch": "3.1.5",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.8.1",
+    "@docusaurus/plugin-client-redirects": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-mermaid": "^3.8.1",
     "@mdx-js/react": "^3.0.0",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -708,7 +708,7 @@ export default function Home() {
               </div>
               <div className="section-header-right-col">
                 <Link className="section-header-cta" to="/users/getting-started">Read end user guides →</Link>
-                <Link className="section-header-cta" to="/developers/serviceprovider/service-providers">Contribute ServiceProvider →</Link>
+                <Link className="section-header-cta" to="/developers/serviceprovider/develop">Contribute ServiceProvider →</Link>
               </div>
             </div>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds explicit `id:` frontmatter to all documentation pages. Docusaurus auto-generates URLs from filenames by default, which means numeric prefixes like `01-setup.md` end up in URLs (`/operators/01-setup`). Using `id:` overrides just the filename part while keeping URLs tied to the folder structure.

Also includes:
- Redirect from the old `/developers/serviceprovider/service-providers` URL to `/developers/serviceprovider/develop`
- Fixed duplicate `sidebar_position: 0` in the operators section
- Added `sidebar_position` to concept pages for consistent ordering
- Added `CLAUDE.md` documenting the `id:` requirement for future contributors
- Renamed `02-service-providers.mdx` to `02-develop.mdx` to match its `id`

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Uses `id:` instead of `slug:` per reviewer feedback — this keeps the folder structure visible in URLs while only overriding the filename part.

**Release note**:
```
Documentation URLs are now clean (no numeric prefixes) and stable.
```