### PR TITLE
docs: add redirect requirement for ID changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,28 @@ The resulting URL will be `/operators/setup` (folder path + id).
 
 Pages without an `id:` field will use the filename as-is, including any numeric prefixes — always add one when creating or renaming a page.
 
+### Avoiding breaking URLs
+
+When changing an existing `id:`, you **must** add a redirect in `docusaurus.config.ts` to preserve the old URL:
+
+```ts
+plugins: [
+  [
+    '@docusaurus/plugin-client-redirects',
+    {
+      redirects: [
+        {
+          from: '/old/path',
+          to: '/new/path',
+        },
+      ],
+    },
+  ],
+],
+```
+
+This ensures external links and bookmarks continue to work after ID changes.
+
 ## Branch workflow
 
 Work on feature branches based on `main`. Merge via PR.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a requirement to CLAUDE.md: When changing an existing `id:`, a redirect must be added to `docusaurus.config.ts` to preserve the old URL. Includes a code example showing how to configure redirects.

This ensures external links and bookmarks continue to work after ID changes.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Follow-up to PR #80 which introduced the `id:` requirement.

**Release note**:
```doc developer
CLAUDE.md now requires adding redirects when changing document IDs to prevent breaking URLs.
```