### PR TITLE
feat: add documentation for service provider kro

### DIFF
--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -80,6 +80,7 @@ Special Interest Group focused on making it easy to build, share, and adopt exte
 - [Landscaper service provider](https://github.com/openmcp-project/service-provider-landscaper)
 - [Velero service provider](https://github.com/openmcp-project/service-provider-velero)
 - [OCM service provider](https://github.com/open-component-model/service-provider-ocm)
+- [Kro service provider](https://github.com/openmcp-project/service-provider-kro)
 - [Service provider template](https://github.com/openmcp-project/repository-template)
 
 **Cluster Providers:**

--- a/docs/developers/serviceprovider/03-examples.mdx
+++ b/docs/developers/serviceprovider/03-examples.mdx
@@ -65,6 +65,19 @@ Community Service Providers that extend OpenControlPlane. Use these as inspirati
 
 <div className="project-card">
   <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="project-logo"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    <h3>service-provider-kro</h3>
+  </div>
+  <div className="project-description">
+    Installs and manages Kro (Kube Resource Orchestrator) on workload clusters, enabling custom Kubernetes APIs composed from existing resources.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/service-provider-kro" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a>
+  </div>
+</div>
+
+<div className="project-card">
+  <div className="project-card-header">
     <img src="/docs/img/logos/kyverno.png" alt="Kyverno Service Provider" className="project-logo" />
     <h3>service-provider-kyverno</h3>
   </div>

--- a/docs/reference/00-overview.md
+++ b/docs/reference/00-overview.md
@@ -109,6 +109,15 @@ Available service providers that can be deployed within control planes.
   <a href="/docs/reference/services/ocm" className="reference-link">View CRD →</a>
 </div>
 
+<div className="reference-card">
+  <div className="reference-icon-container reference-icon-container-standard">
+    <img src="/docs/img/platform/tower.png" alt="Kro" className="reference-icon-large" />
+  </div>
+  <h3>Kro</h3>
+  <p>Custom Kubernetes APIs composed from existing resources using Kro.</p>
+  <a href="/docs/reference/services/kro" className="reference-link">View CRD →</a>
+</div>
+
 </div>
 
 ## Operator Resources
@@ -184,3 +193,4 @@ CRD definitions are maintained across multiple repositories:
   - Landscaper: [service-provider-landscaper](https://github.com/openmcp-project/service-provider-landscaper/tree/main/api/crds/manifests)
   - Velero: [service-provider-velero](https://github.com/openmcp-project/service-provider-velero/tree/main/api/crds/manifests)
   - OCM: [service-provider-ocm](https://github.com/open-component-model/service-provider-ocm/tree/main/api/crds/manifests)
+  - Kro: [service-provider-kro](https://github.com/openmcp-project/service-provider-kro/tree/main/api/crds/manifests)

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 5
+id: kro
+---
+
+import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
+
+# Kro
+
+<div className="crd-header-container">
+  <img src="/docs/img/platform/tower.png" alt="Kro" className="crd-header-icon" />
+  <div className="crd-header-text">
+    <p>Delivers Kro (Kube Resource Orchestrator) as a service within ManagedControlPlanes, enabling custom Kubernetes APIs composed from existing resources.</p>
+  </div>
+</div>
+
+**API Group:** `kro.services.openmcp.cloud`
+**API Version:** `v1alpha1`
+**Kind:** `Kro`
+
+<CRDViewerCompact
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-kro/main/api/crds/manifests/kro.services.openmcp.cloud_kroes.yaml"
+  name="Kro"
+  description="Kro service provider resource"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-kro/main/test/e2e/onboarding/kro.yaml"
+/>
+
+## Usage
+
+Deploy Kro within a control plane:
+
+```yaml
+apiVersion: kro.services.openmcp.cloud/v1alpha1
+kind: Kro
+metadata:
+  name: my-controlplane
+  namespace: project-platform-team--ws-dev
+spec:
+  version: 0.9.1
+```
+
+The Kro service provider installs the [Kro](https://kro.run) controller into the `kro-system` namespace on your ManagedControlPlane via a Flux `HelmRelease`. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform operator.
+
+The name of the `Kro` resource **must** match the name of your ManagedControlPlane. This guarantees a single Kro installation per control plane.

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -116,6 +116,41 @@ Events:
 The base OCM installation comes with a bare minimum set of RBAC settings. To extend this, follow the [custom RBAC for OCM](https://github.com/open-component-model/open-component-model/blob/main/kubernetes/controller/docs/getting-started/custom-rbac.md) guide. Since you are an admin on the ControlPlane, extending the service account's RBAC should work.
 
 </TabItem>
+<TabItem value="kro" label="Kro">
+
+[Kro](https://kro.run) (Kube Resource Orchestrator) lets you create custom Kubernetes APIs by composing existing resources into higher-level abstractions. The service provider installs the Kro controller into the `kro-system` namespace on your ControlPlane via a Flux `HelmRelease`.
+
+To install the Kro operator for your ControlPlane, create a `Kro` resource in the same namespace and with the same name as your ControlPlane object:
+
+```yaml
+apiVersion: kro.services.openmcp.cloud/v1alpha1
+kind: Kro
+metadata:
+  name: my-controlplane
+  namespace: project-platform-team--ws-dev
+spec:
+  version: 0.9.1
+```
+
+```bash
+kubectl apply -f kro.yaml
+```
+
+Once this object reconciles, you can verify the Kro controller is running on the ControlPlane:
+
+```bash
+# Make sure you are using the kubeconfig for the ControlPlane
+kubectl get pods -n kro-system
+```
+
+```
+NAME                              READY   STATUS    RESTARTS   AGE
+kro-7d9c6f8b54-abcde              1/1     Running   0          45s
+```
+
+The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by your platform operator. See the [service-provider-kro README](https://github.com/openmcp-project/service-provider-kro#providerconfig) for the full set of tunables.
+
+</TabItem>
 </Tabs>
 
 ---
@@ -129,3 +164,4 @@ Congratulations! You have a working ControlPlane with managed services. Here's w
 - **[Crossplane Service Provider](https://github.com/openmcp-project/service-provider-crossplane)** — Manage cloud infrastructure
 - **[Landscaper Service Provider](https://github.com/openmcp-project/service-provider-landscaper)** — Orchestrate complex workloads
 - **[OCM Service Provider](https://github.com/open-component-model/service-provider-ocm)** — Deliver and deploy software with the Open Component Model
+- **[Kro Service Provider](https://github.com/openmcp-project/service-provider-kro)** — Compose custom Kubernetes APIs with Kro


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds documentation and CRD browser for the Kro service provider.

**Which issue(s) this PR fixes**:

Part of https://github.com/open-component-model/ocm-project/issues/1011.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add service provider kro end user documentation.
```