### PR TITLE
docs(sp-dev-guide): provider config guideline updates

### DIFF
--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -187,37 +187,16 @@ Service providers must expose a `ProviderConfig` which platform operators use to
 
 ### ProviderConfig Guidelines
 
-When designing your `ProviderConfig`, **only include controller operational settings** - configuration that controls how your controller reconciles, not what it deploys or what tenants can use.
-Operational settings include reconciliation behavior, timeouts, observability, feature toggles, and trust configuration (CA bundles).
+At the time of writing, the design of a `ProviderConfig` must address the following concerns:
 
-**Do not include** deployment artifacts (images, charts, versions) or tenant constraints (version policies, available providers).
+1. Deployment prerequisites for restricted environments: A `ProviderConfig` **must** expose the configuration required to deploy a service provider in private or aig-gapped environments, for example by specifying image and Helm chart pull secrets.
+2. Constraining deployable domain service versions: A `ProviderConfig` **may** expose configuration that constraints which versions of a domain service the service provider is allowed to deploy. This enables platform operators to explicitly define an approved set of versions.
+It is encouraged to add this for new service providers until dedicated Registry and TenantPolicy systems will replace this in the future (see [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)) .
+3. Runtime behavior: A `ProviderConfig` **may** expose configuration settings that influence the runtime behavior of a service provider, such as the poll interval used in the service provider template.
 
-:::info Temporary Necessity
-Information about deployment artifacts and tenant constraints will move to dedicated Registry and TenantPolicy systems in the future (see [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)). Until then, some Service Providers include these concerns in their `ProviderConfig` as a temporary measure. Structure your API to allow graceful deprecation of deployment artifact and tenant constraint fields when the Registry and TenantPolicy systems become available.
-:::
+### ProviderConfig Example
 
-
-### Ideal Minimal ProviderConfig
-
-A well-designed `ProviderConfig` contains **only controller operational settings**:
-
-```yaml
-apiVersion: myservice.services.openmcp.cloud/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  # Reconciliation behavior
-  pollInterval: 1m
-  maxConcurrentReconciles: 5
-
-  # Timeouts
-  helmReleaseTimeout: 10m
-```
-
-### Current State: When You Need More
-
-For example, Velero's ProviderConfig currently includes both operational settings and deployment artifacts:
+Velero's ProviderConfig currently includes both operational settings and deployment artifacts:
 
 ```yaml
 apiVersion: velero.services.openmcp.cloud/v1alpha1
@@ -674,8 +653,8 @@ In here, the values, for example, could come from the `ProviderConfig`. Or furth
 being created as a first step.
 
 :::warning
-If secrets need to be copied into tenant namespaces on the platform cluster (e.g. to access an OCIRepository with a Helm chart), the secret name must be adjusted to avoid conflicts with other service providers.
-Use a service‑provider–specific prefix for the copied secret, e.g. rename privateregcred to sp-crossplane-privateregcred. Make sure the resulting name does not exceed the allowed [max name length](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+Any resources created in a tenant namespace on the platform cluster (e.g. a pull secret to access an OCIRepository with a Helm chart), the resource name must be adjusted to avoid conflicts with other service providers.
+Use a service‑provider–specific prefix for the resource, e.g. rename privateregcred to sp-crossplane-privateregcred. Make sure the resulting name does not exceed the allowed [max name length](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
 :::
 
 Also notice the `KubeConfig` section. Your service provider controller is deployed in the Platform cluster. The target controller that your provider is deploying

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -190,8 +190,8 @@ Service providers must expose a `ProviderConfig` which platform operators use to
 At the time of writing, the design of a `ProviderConfig` must address the following concerns:
 
 1. Deployment prerequisites for restricted environments: A `ProviderConfig` **must** expose the configuration required to deploy a service provider in private or aig-gapped environments, for example by specifying image and Helm chart pull secrets.
-2. Constraining deployable domain service versions: A `ProviderConfig` **may** expose configuration that constraints which versions of a domain service the service provider is allowed to deploy. This enables platform operators to explicitly define an approved set of versions.
-It is encouraged to add this for new service providers until dedicated Registry and TenantPolicy systems will replace this in the future (see [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)).
+2. Constraining deployable domain service versions: A `ProviderConfig` **must** expose configuration that constraints which versions of a domain service the service provider is allowed to deploy. This enables platform operators to explicitly define an approved set of versions.
+It is required to add this for new service providers until dedicated Registry and TenantPolicy systems will replace this in the future (see [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)).
 3. Runtime behavior: A `ProviderConfig` **may** expose configuration settings that influence the runtime behavior of a service provider, such as the poll interval used in the service provider template.
 
 ### ProviderConfig Example

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -191,7 +191,7 @@ At the time of writing, the design of a `ProviderConfig` must address the follow
 
 1. Deployment prerequisites for restricted environments: A `ProviderConfig` **must** expose the configuration required to deploy a service provider in private or aig-gapped environments, for example by specifying image and Helm chart pull secrets.
 2. Constraining deployable domain service versions: A `ProviderConfig` **may** expose configuration that constraints which versions of a domain service the service provider is allowed to deploy. This enables platform operators to explicitly define an approved set of versions.
-It is encouraged to add this for new service providers until dedicated Registry and TenantPolicy systems will replace this in the future (see [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)) .
+It is encouraged to add this for new service providers until dedicated Registry and TenantPolicy systems will replace this in the future (see [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)).
 3. Runtime behavior: A `ProviderConfig` **may** expose configuration settings that influence the runtime behavior of a service provider, such as the poll interval used in the service provider template.
 
 ### ProviderConfig Example

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -653,8 +653,8 @@ In here, the values, for example, could come from the `ProviderConfig`. Or furth
 being created as a first step.
 
 :::warning
-Any resources created in a tenant namespace on the platform cluster (e.g. a pull secret to access an OCIRepository with a Helm chart), the resource name must be adjusted to avoid conflicts with other service providers.
-Use a service‑provider–specific prefix for the resource, e.g. rename privateregcred to sp-crossplane-privateregcred. Make sure the resulting name does not exceed the allowed [max name length](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+Any resource created in a tenant namespace on the platform cluster (e.g. a pull secret to access an OCIRepository with a Helm chart) must have a carefully chosen name to avoid conflicts with other service providers.
+Use a service‑provider–specific prefix for the resource, e.g. rename privateregcred to sp-crossplane-privateregcred for pull secret copies. Make sure the resulting name does not exceed the allowed [max name length](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
 :::
 
 Also notice the `KubeConfig` section. Your service provider controller is deployed in the Platform cluster. The target controller that your provider is deploying


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Clarifies current recommendations regarding provider config design.
Additionally adjusts the previously secret specific prefixing recommendation to apply for any resource that a provider creates in a (shared) tenant namespace.

**Which issue(s) this PR fixes**:
Part of https://github.com/openmcp-project/service-provider-flux/issues/37

**Special notes for your reviewer**:
I prefer to specify point 2 as must to have a clear guideline regarding versions until we have an alternative solution. but let me know what you think.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```