### PR TITLE
feat: add Osano cookie consent script

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -9,6 +9,15 @@ const config: Config = {
   tagline: 'Part of ApeiroRA and NeoNephos.',
   favicon: 'img/favicon.ico',
 
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {
+        src: 'https://cmp.osano.com/16A0DbT9yDNIaQkvZ/af2b9f1f-3ac7-4a18-a99a-e487d04f08e6/osano.js',
+      },
+    },
+  ],
+
   // Set the production url of your site here
   url: 'https://openmcp-project.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served


### PR DESCRIPTION
## What

Adds the Osano CMP (Consent Management Platform) script to the site `<head>` for cookie consent validation.

```html
<script src="https://cmp.osano.com/16A0DbT9yDNIaQkvZ/af2b9f1f-3ac7-4a18-a99a-e487d04f08e6/osano.js"></script>
```

## Why

Required for LF Europe cookie compliance. Part of https://github.com/openmcp-project/backlog/issues/533.

Fixes https://github.com/openmcp-project/docs/issues/91