### PR TITLE
feat: Reorder serviceprovider docs to match the developer workflow

### DIFF
--- a/docs/developers/clusterprovider/04-design.mdx
+++ b/docs/developers/clusterprovider/04-design.mdx
@@ -11,4 +11,4 @@ Detailed design documentation for Cluster Providers is coming soon.
 
 Cluster Providers are responsible for managing Kubernetes clusters and providing access to them within the OpenControlPlane ecosystem. They follow similar architectural patterns to Service Providers.
 
-For reference, you can review the [Service Provider Design Documentation](../serviceprovider/04-design.mdx) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.
+For reference, you can review the [Service Provider Design Documentation](../serviceprovider/01-design.mdx) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.

--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -85,7 +85,7 @@ The Platform Cluster runs all operators. Tenant resources are isolated using nam
 The `mcp--<uuid>` namespaces are created and managed automatically by the platform.
 
 :::info
-The `POD_NAMESPACE` environment variable, available to all provider pods, refers to the provider's namespace on the Platform Cluster (typically `openmcp-system`). See the [deployment guide](./serviceprovider/01-deployment.mdx) for all available environment variables.
+The `POD_NAMESPACE` environment variable, available to all provider pods, refers to the provider's namespace on the Platform Cluster (typically `openmcp-system`). See the [deployment guide](./serviceprovider/04-deployment.mdx) for all available environment variables.
 :::
 
 ### MCP Cluster
@@ -109,7 +109,7 @@ Each service provider must use a unique namespace per tenant service instance. F
 | `<provider>-<instance-id>` (e.g., `ls-system-<id>`) | Service provider workloads, isolated per tenant |
 
 :::info
-Newly developed services should prioritize deploying their workloads on Workload Clusters rather than MCP Clusters. See the [service provider design](./serviceprovider/04-design.mdx#deployment-model) for details.
+Newly developed services should prioritize deploying their workloads on Workload Clusters rather than MCP Clusters. See the [service provider design](./serviceprovider/01-design.mdx#deployment-model) for details.
 :::
 
 ## Real-World Examples

--- a/docs/developers/platformprovider/01-deployment.mdx
+++ b/docs/developers/platformprovider/01-deployment.mdx
@@ -9,4 +9,4 @@ id: deploy
 Documentation for deploying Platform Providers is coming soon. Platform Providers follow the same deployment contract as Service Providers and Cluster Providers.
 :::
 
-For now, please refer to the [Service Provider Deploy Guide](../serviceprovider/01-deployment.mdx) for the common deployment contract that applies to all provider types.
+For now, please refer to the [Service Provider Deploy Guide](../serviceprovider/04-deployment.mdx) for the common deployment contract that applies to all provider types.

--- a/docs/developers/platformprovider/05-design.mdx
+++ b/docs/developers/platformprovider/05-design.mdx
@@ -11,4 +11,4 @@ Detailed design documentation for Platform Providers is coming soon.
 
 Platform Providers deliver complete platform capabilities within the OpenControlPlane ecosystem. They follow similar architectural patterns to Service Providers and Cluster Providers.
 
-For reference, you can review the [Service Provider Design Documentation](../serviceprovider/04-design.mdx) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.
+For reference, you can review the [Service Provider Design Documentation](../serviceprovider/01-design.mdx) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.

--- a/docs/developers/serviceprovider/01-design.mdx
+++ b/docs/developers/serviceprovider/01-design.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 1
 id: design
 ---
 

--- a/docs/developers/serviceprovider/03-testing.mdx
+++ b/docs/developers/serviceprovider/03-testing.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 3
 id: testing
 ---
 

--- a/docs/developers/serviceprovider/04-deployment.mdx
+++ b/docs/developers/serviceprovider/04-deployment.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 4
 id: deploy
 ---
 

--- a/docs/developers/serviceprovider/05-examples.mdx
+++ b/docs/developers/serviceprovider/05-examples.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 5
 id: examples
 ---
 
@@ -123,6 +123,6 @@ Community Service Providers that extend OpenControlPlane. Use these as inspirati
 
 </div>
 
-These projects serve as reference implementations for building Service Providers. Check out the [Deploy Guide](./01-deployment.mdx) to create your own, or contribute improvements to existing providers.
+These projects serve as reference implementations for building Service Providers. Check out the [Deploy Guide](./04-deployment.mdx) to create your own, or contribute improvements to existing providers.
 
 **Want to get involved?** Join our developer community through [SIG Extensibility](https://github.com/openmcp-project/community/tree/main/sig-extensibility) - see the [Build Together overview](../getting-started#join-the-community) for details on how to connect with other provider developers.


### PR DESCRIPTION
**What this PR does / why we need it**:
Reorders the serviceprovider documentation pages to follow the natural developer workflow (understand → build → test → ship → browse references).                                                              
                                                                                                                                                                                                                   **Before:**
1. Deploy                                                                                                                                                                                                        
2. Develop                                                                                                                                                                                                       
3. Examples                                                                                                                                                                                                    
4. Design                                                                                                                                                                                                        
5. Testing                                                                                                                                                                                                     
                                                                                                                                                                                                                 
**After:**
1. Design
2. Develop
3. Testing
4. Deploy 
5. Examples

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Reorder serviceprovider docs to match the developer workflow.
```