### PR TITLE
feat: Add debugging guide for service provider developers

### DIFF
--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -85,7 +85,7 @@ The Platform Cluster runs all operators. Tenant resources are isolated using nam
 The `mcp--<uuid>` namespaces are created and managed automatically by the platform.
 
 :::info
-The `POD_NAMESPACE` environment variable, available to all provider pods, refers to the provider's namespace on the Platform Cluster (typically `openmcp-system`). See the [deployment guide](./serviceprovider/04-deployment.mdx) for all available environment variables.
+The `POD_NAMESPACE` environment variable, available to all provider pods, refers to the provider's namespace on the Platform Cluster (typically `openmcp-system`). See the [deployment guide](./serviceprovider/05-deployment.mdx) for all available environment variables.
 :::
 
 ### MCP Cluster

--- a/docs/developers/platformprovider/01-deployment.mdx
+++ b/docs/developers/platformprovider/01-deployment.mdx
@@ -9,4 +9,4 @@ id: deploy
 Documentation for deploying Platform Providers is coming soon. Platform Providers follow the same deployment contract as Service Providers and Cluster Providers.
 :::
 
-For now, please refer to the [Service Provider Deploy Guide](../serviceprovider/04-deployment.mdx) for the common deployment contract that applies to all provider types.
+For now, please refer to the [Service Provider Deploy Guide](../serviceprovider/05-deployment.mdx) for the common deployment contract that applies to all provider types.

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -80,7 +80,7 @@ go run ./cmd/template -v -w -module github.com/openmcp-project/service-provider-
 ```
 :::
 
-For a detailed guide to the [openmcp-testing](https://github.com/openmcp-project/openmcp-testing) testing framework, test structure, and examples, see the [Testing guide](./testing).
+For a detailed guide to the [openmcp-testing](https://github.com/openmcp-project/openmcp-testing) testing framework, test structure, and examples, see the [Testing guide](./testing). For running your controller locally outside the cluster and troubleshooting common issues, see the [Debug guide](./debugging).
 
 The template generator removes its own code after execution. If you want to revert your changes and start fresh, simply use git and delete any generated untracked files. For this reason, remove template-generation step from the e2e test `.github/workflows/go.yaml` before committing your changes (otherwise your workflow will fail).
 

--- a/docs/developers/serviceprovider/03-debugging.mdx
+++ b/docs/developers/serviceprovider/03-debugging.mdx
@@ -17,7 +17,7 @@ Use the `local-dev.sh` script from [cluster-provider-kind](https://github.com/op
 ./hack/local-dev.sh deploy
 ```
 
-This creates a KinD-based platform cluster with the OpenMCP operator, cluster provider, and any configured service providers.
+This creates a KinD-based Platform cluster with the OpenMCP operator, cluster provider, and any configured service providers.
 
 To tear everything down and start fresh:
 
@@ -51,7 +51,15 @@ By default, `./hack/local-dev.sh` will set the current context to the **Onboardi
 ```bash
 ./hack/local-dev.sh access-platform-cluster --force
 ```
-This switches your current kubectl context to the platform cluster. Your previous context is saved so you can restore it later.
+This switches your current kubectl context to the Platform cluster. Your previous context is saved so you can restore it later.
+
+To obtain the Platform cluster kubeconfig:
+
+```bash
+./hack/local-dev.sh access-platform-cluster
+```
+
+This prints the path and the exact `export` command to use, e.g. `export KUBECONFIG=/tmp/platform-kubeconfig-AP8A8l`. You can use this later to run your service provider outside of the cluster.
 
 ### Managing Multiple Kubeconfigs with kw
 
@@ -101,20 +109,27 @@ The operator also injects these environment variables into the pod:
 | `POD_IP` | IP address of the pod |
 | `POD_SERVICE_ACCOUNT_NAME` | Service account running the pod |
 
-You need to supply the flags and environment variables that the operator would normally provide:
+You need to supply the flags and environment variables that the operator would normally provide, plus enable debug mode to use locally-reachable cluster addresses:
 
 ```bash
-POD_NAMESPACE=<provider-pod-namespace> go run ./cmd/<your-service-provider>/main.go run \
+KUBECONFIG=<path-to-platform-kubeconfig> \
+POD_NAMESPACE=openmcp-system \
+DEV_DEBUG=true \
+go run ./cmd/<your-service-provider>/main.go run \
   --environment local \
   --provider-name <your-provider-name> \
   --verbosity DEBUG
 ```
 
+The `DEV_DEBUG=true` flag activates local debug mode: instead of using the in-cluster API server addresses for the Onboarding, MCP or Workload clusters, the controller reads the `kind.clusters.openmcp.cloud/localhost` annotation from the corresponding `AccessRequest` objects and uses those locally-reachable addresses instead.
 :::tip
-Before running the `run` subcommand for the first time, you need to initialize the CRDs on the target clusters by running the `init` subcommand with the same flags:
+Before running the `run` subcommand for the first time, you need to initialize the CRDs on the target clusters by running the `init` subcommand with the same environment variables and flags:
 
 ```bash
-POD_NAMESPACE=<provider-pod-namespace> go run ./cmd/<your-service-provider>/main.go init \
+KUBECONFIG=<path-to-platform-kubeconfig> \
+POD_NAMESPACE=openmcp-system \
+DEV_DEBUG=true \
+go run ./cmd/<your-service-provider>/main.go init \
   --environment local \
   --provider-name <your-provider-name> \
   --verbosity DEBUG
@@ -211,7 +226,7 @@ kind load docker-image <your-image>:<tag> --name platform
 If your controller fails to connect to the MCP or workload cluster, verify that the AccessRequest was created and that the corresponding kubeconfig secret exists:
 
 ```bash
-# On the platform cluster, in the tenant namespace
+# On the Platform cluster, in the tenant namespace
 kubectl get accessrequests -n mcp--<uuid>
 kubectl get secrets -n mcp--<uuid>
 ```

--- a/docs/developers/serviceprovider/03-debugging.mdx
+++ b/docs/developers/serviceprovider/03-debugging.mdx
@@ -39,7 +39,7 @@ A service provider operates across multiple clusters. During debugging, you need
 | Cluster | What to look for |
 |---------|-----------------|
 | **Platform** | ProviderConfig, AccessRequests, kubeconfig secrets, SP pod logs |
-| **Onboarding** | ServiceProviderAPI objects in workspace namespaces |
+| **Onboarding** | ManagedControlPlane and ServiceProviderAPI objects |
 | **MCP** | DomainService CRDs and deployed resources |
 | **Workload** (optional) | DomainService controller workloads |
 

--- a/docs/developers/serviceprovider/03-debugging.mdx
+++ b/docs/developers/serviceprovider/03-debugging.mdx
@@ -1,0 +1,225 @@
+---
+sidebar_position: 3
+id: debugging
+---
+
+# Debug
+
+This guide helps you run and debug your service provider during local development. It assumes you are developing based on the [service-provider-template](https://github.com/openmcp-project/service-provider-template) and running a local OpenMCP installation via [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind).
+
+## Local Development Setup
+
+### Deploy a Local Installation
+
+Use the `local-dev.sh` script from [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind) to spin up a full local OpenMCP environment:
+
+```bash
+./hack/local-dev.sh deploy
+```
+
+This creates a KinD-based platform cluster with the OpenMCP operator, cluster provider, and any configured service providers.
+
+To tear everything down and start fresh:
+
+```bash
+./hack/local-dev.sh reset --force
+```
+
+:::tip
+Run `./hack/local-dev.sh help` to see all available subcommands and environment variables. The script allows you to override images and versions for multiple components (operator, cluster provider, service providers) via environment variables.
+:::
+
+
+## Accessing Clusters
+
+A service provider operates across multiple clusters. During debugging, you need to switch between them frequently to inspect resources, read logs, or check status. However, you will be mainly working with the **Platform Cluster**, as that's where service providers run.
+
+### Cluster Contexts
+
+| Cluster | What to look for |
+|---------|-----------------|
+| **Platform** | ProviderConfig, AccessRequests, kubeconfig secrets, SP pod logs |
+| **Onboarding** | ServiceProviderAPI objects in workspace namespaces |
+| **MCP** | DomainService CRDs and deployed resources |
+| **Workload** (optional) | DomainService controller workloads |
+
+For a full overview, see [Clusters and Namespaces](../clusters-and-namespaces.md).
+
+### Switch to the Platform Cluster
+By default, `./hack/local-dev.sh` will set the current context to the **Onboarding** cluster context when it's done. This is because this is the expected user entrypoint to the system. However, as a service provider developer, you will probably need to access the **Platform** cluster. You can use the script to quickly switch to its context:
+
+```bash
+./hack/local-dev.sh access-platform-cluster --force
+```
+This switches your current kubectl context to the platform cluster. Your previous context is saved so you can restore it later.
+
+### Managing Multiple Kubeconfigs with kw
+
+For complex providers, you will find that you need to jump between multiple clusters. For this case, you can use [kw (KubeSwitcher)](https://github.com/Diaphteiros/kw) which will help you manage multiple kubeconfigs per shell session:
+
+```bash
+# Switch to a kubeconfig file
+kw custom <path-to-kubeconfig>
+
+# Bookmark the current cluster for quick access later
+kw bookmark save platform
+
+# Flip back to the previous cluster
+kw flip
+
+# Load a bookmarked cluster
+kw bookmark load platform
+```
+
+This is especially useful when you need to cross-reference resources across the platform, MCP, and workload clusters during a debugging session. See the [kw repo](https://github.com/Diaphteiros/kw) for the full list of commands and features.
+
+## Running Your Controller Locally
+
+For faster iteration, you can run your controller outside the cluster. This lets you use a debugger, see logs directly in your terminal, and skip the image build/load cycle.
+
+### Subcommands and Flags
+
+In production, the operator runs your service provider binary with two subcommands (see [Deployment Contract](deploy#common-provider-contract)):
+
+- **`init`** — runs as a Job to install CRDs whenever the provider version changes.
+- **`run`** — runs as a Deployment to start the reconciliation loop.
+
+Both subcommands receive the following flags from the operator:
+
+| Flag | Description |
+|------|-------------|
+| `--environment` | Name of the environment (e.g. `canary`, `live`) |
+| `--provider-name` | Name of the `ServiceProvider` resource |
+| `--verbosity` | Logging verbosity: `ERROR`, `INFO`, or `DEBUG` |
+
+The operator also injects these environment variables into the pod:
+
+| Variable | Description |
+|----------|-------------|
+| `POD_NAME` | Name of the pod |
+| `POD_NAMESPACE` | Namespace of the pod (used to locate secrets), set by the operator (typically `openmcp-system`) |
+| `POD_IP` | IP address of the pod |
+| `POD_SERVICE_ACCOUNT_NAME` | Service account running the pod |
+
+You need to supply the flags and environment variables that the operator would normally provide:
+
+```bash
+POD_NAMESPACE=<provider-pod-namespace> go run ./cmd/<your-service-provider>/main.go run \
+  --environment local \
+  --provider-name <your-provider-name> \
+  --verbosity DEBUG
+```
+
+:::tip
+Before running the `run` subcommand for the first time, you need to initialize the CRDs on the target clusters by running the `init` subcommand with the same flags:
+
+```bash
+POD_NAMESPACE=<provider-pod-namespace> go run ./cmd/<your-service-provider>/main.go init \
+  --environment local \
+  --provider-name <your-provider-name> \
+  --verbosity DEBUG
+```
+
+Re-run `init` whenever you change your CRD definitions.
+:::
+
+### Additional Logging Flags
+
+On top of the `--verbosity` flag passed by the operator, every service provider binary registers additional logging flags via the shared [`controller-utils/pkg/logging`](https://github.com/openmcp-project/controller-utils/tree/main/pkg/logging) package. These are useful during local development:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--dev` | Development mode (sets verbosity to `debug`) | `false` |
+| `--cli` | Colored, human-readable output without timestamps | `false` |
+| `-f` / `--format` | Output format: `text` or `json` | `text` if `--dev` or `--cli`, `json` otherwise |
+| `--disable-stacktrace` | Suppress error stacktraces | `true` |
+| `--disable-caller` | Suppress caller info | `true` |
+| `--disable-timestamp` | Suppress timestamps | `false` |
+
+For example, to get colored debug output during local development:
+
+```bash
+POD_NAMESPACE=<provider-pod-namespace> go run ./cmd/<your-service-provider>/main.go run \
+  --environment local \
+  --provider-name <your-provider-name> \
+  --dev \
+  --cli
+```
+
+## Inspecting Resources and Status
+
+### Status Fields
+
+Every service provider resource should report its state through a standard set of status fields:
+
+| Field | Meaning |
+|-------|---------|
+| `phase` | Aggregated state: `Ready`, `Progressing`, or `Uninstalling` |
+| `conditions` | Detailed condition list — check here first when `phase` is not `Ready` |
+| `observedGeneration` | Last `.metadata.generation` the controller reconciled — if it lags behind, the controller hasn't picked up the latest spec yet |
+
+Inspect the status of your resources:
+
+```bash
+kubectl get <resource> -A
+kubectl describe <resource> -n <namespace> <name>
+```
+
+### Triggering or Preventing Reconciliation
+
+Use the `openmcp.cloud/operation` annotation to manually control reconciliation:
+
+```bash
+# Force a reconciliation (annotation is removed automatically afterwards)
+kubectl annotate <resource> -n <namespace> <name> openmcp.cloud/operation=reconcile
+
+# Prevent reconciliation entirely (useful for inspecting state without interference)
+kubectl annotate <resource> -n <namespace> <name> openmcp.cloud/operation=ignore
+```
+
+To resume normal reconciliation after `ignore`, remove the annotation:
+
+```bash
+kubectl annotate <resource> -n <namespace> <name> openmcp.cloud/operation-
+```
+
+## Common Issues
+
+### CRD Updates Not Reflected on the Clusters
+
+If you changed your CRD definitions but the clusters still have the old version, the `init` subcommand needs to run again. In a deployed environment, `init` runs automatically as a Job whenever the provider version changes. During local development, you need to re-run it manually:
+
+```bash
+POD_NAMESPACE=<provider-pod-namespace> go run ./cmd/<your-service-provider>/main.go init \
+  --environment local \
+  --provider-name <your-provider-name> \
+  --verbosity DEBUG
+```
+
+If `init` fails, check its logs for errors (e.g. schema validation failures or missing cluster access).
+
+### Image Not Loaded into KinD
+
+If your pod is stuck in `ImagePullBackOff`, the image was likely not loaded into the KinD cluster. After building with `task build:img:build-test`, make sure the image is available inside the cluster. The `local-dev.sh` script handles this for known providers, but for your own SP you may need to load it manually:
+
+```bash
+kind load docker-image <your-image>:<tag> --name platform
+```
+
+### Cluster Access or Kubeconfig Secrets Missing
+
+If your controller fails to connect to the MCP or workload cluster, verify that the AccessRequest was created and that the corresponding kubeconfig secret exists:
+
+```bash
+# On the platform cluster, in the tenant namespace
+kubectl get accessrequests -n mcp--<uuid>
+kubectl get secrets -n mcp--<uuid>
+```
+
+### Reconciliation Not Triggering
+
+If your controller is not reacting to changes:
+
+- Check that `observedGeneration` is up to date — if it matches `.metadata.generation`, the controller saw the change but may have decided no action is needed.
+- Verify your watch predicates aren't filtering out the event.
+- Use the `openmcp.cloud/operation=reconcile` annotation to force a run and observe the logs.

--- a/docs/developers/serviceprovider/03-debugging.mdx
+++ b/docs/developers/serviceprovider/03-debugging.mdx
@@ -198,6 +198,10 @@ To resume normal reconciliation after `ignore`, remove the annotation:
 kubectl annotate <resource> -n <namespace> <name> openmcp.cloud/operation-
 ```
 
+:::note
+Support for operation annotations is service-provider-dependent. Even though the [service-provider-template](https://github.com/openmcp-project/service-provider-template) runtime currently respects these annotations, they were not initially supported.  Currently, not all existing service providers include this implementation. You should check the provider's reconciler code to confirm support.
+:::
+
 ## Common Issues
 
 ### CRD Updates Not Reflected on the Clusters
@@ -212,14 +216,6 @@ POD_NAMESPACE=<provider-pod-namespace> go run ./cmd/<your-service-provider>/main
 ```
 
 If `init` fails, check its logs for errors (e.g. schema validation failures or missing cluster access).
-
-### Image Not Loaded into KinD
-
-If your pod is stuck in `ImagePullBackOff`, the image was likely not loaded into the KinD cluster. After building with `task build:img:build-test`, make sure the image is available inside the cluster. The `local-dev.sh` script handles this for known providers, but for your own SP you may need to load it manually:
-
-```bash
-kind load docker-image <your-image>:<tag> --name platform
-```
 
 ### Cluster Access or Kubeconfig Secrets Missing
 

--- a/docs/developers/serviceprovider/04-testing.mdx
+++ b/docs/developers/serviceprovider/04-testing.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 id: testing
 ---
 

--- a/docs/developers/serviceprovider/05-deployment.mdx
+++ b/docs/developers/serviceprovider/05-deployment.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 id: deploy
 ---
 

--- a/docs/developers/serviceprovider/06-examples.mdx
+++ b/docs/developers/serviceprovider/06-examples.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 id: examples
 ---
 
@@ -123,6 +123,6 @@ Community Service Providers that extend OpenControlPlane. Use these as inspirati
 
 </div>
 
-These projects serve as reference implementations for building Service Providers. Check out the [Deploy Guide](./04-deployment.mdx) to create your own, or contribute improvements to existing providers.
+These projects serve as reference implementations for building Service Providers. Check out the [Deploy Guide](deploy) to create your own, or contribute improvements to existing providers.
 
 **Want to get involved?** Join our developer community through [SIG Extensibility](https://github.com/openmcp-project/community/tree/main/sig-extensibility) - see the [Build Together overview](../getting-started#join-the-community) for details on how to connect with other provider developers.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add debugging guide for service provider developers covering local setup, cluster access, running controllers locally and troubleshooting common issues.  

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/docs/issues/38

**Special notes for your reviewer**:
- Large parts of this documentation were generated using AI. I have reviewed them carefully, but this should be taken into consideration anyway.
- This guide written with the assumption that https://github.com/openmcp-project/service-provider-template/issues/60 is implemented already. It's currently in progress.  

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Add debugging guide for service provider developers covering local setup, cluster access, running controllers locally and troubleshooting common issues.  
```