### PR TITLE
fix: rename 'Open Control Plane' to 'OpenControlPlane' throughout docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in the repo
+* @GenosseOtt
+* @maximiliantech

--- a/docs/developers/serviceprovider/01-design.mdx
+++ b/docs/developers/serviceprovider/01-design.mdx
@@ -105,7 +105,7 @@ End users need to be aware of a) the available managed services, and b) valid in
 
 A) The available service offerings are made visible by installing the `ServiceProviderAPI` on the `OnboardingCluster` (see [deployment model](#deployment-model)). This ensures that any platform tenant is aware of all available `ServiceProviderAPIs`. In other words, the platform does not hide its end-user-facing feature set, even if a user belongs to a tenant that cannot successfully consume a specific `ServiceProviderAPI`.
 
-B) Valid input values are communicated through a yet-to-be-defined 'Marketplace'-like API provided by a `PlatformService` (more information with regard to [Discoverability of Open Control Plane components](https://github.com/openmcp-project/backlog/issues/384)). Note: This is still work in progress and outside the scope of this document.
+B) Valid input values are communicated through a yet-to-be-defined 'Marketplace'-like API provided by a `PlatformService` (more information with regard to [Discoverability of OpenControlPlane components](https://github.com/openmcp-project/backlog/issues/384)). Note: This is still work in progress and outside the scope of this document.
 
 ### Deployment Model
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
-  title: 'Open Control Plane',
+  title: 'OpenControlPlane',
   tagline: 'Part of ApeiroRA and NeoNephos.',
   favicon: 'img/favicon.ico',
 
@@ -94,9 +94,9 @@ const config: Config = {
     // Replace with your project's social card
     image: 'img/co_axolotl.png',
     navbar: {
-      title: 'Open Control Plane',
+      title: 'OpenControlPlane',
       logo: {
-        alt: 'Open Control Plane Logo',
+        alt: 'OpenControlPlane Logo',
         src: 'img/co_axolotl_mirrored.png',
       },
       items: [

--- a/src/pages/about/legal-disclosure.md
+++ b/src/pages/about/legal-disclosure.md
@@ -1,6 +1,6 @@
 ---
 title: Legal Disclosure
-description: Legal Disclosure / Impressum for Open Control Plane
+description: Legal Disclosure / Impressum for OpenControlPlane
 ---
 
 # Legal Disclosure / Impressum

--- a/src/pages/about/privacy.md
+++ b/src/pages/about/privacy.md
@@ -1,6 +1,6 @@
 ---
 title: Privacy Statement
-description: Privacy Statement for Open Control Plane
+description: Privacy Statement for OpenControlPlane
 ---
 
 # Privacy Statement
@@ -13,7 +13,7 @@ Hasso-Plattner-Ring 7
 
 Email: [privacy@sap.com](mailto:privacy@sap.com)
 
-SAP Deutschland SE & Co. KG ("SAP", "we", "us") is the controller responsible for processing your personal data when you visit the Open Control Plane documentation website at [openmcp-project.github.io/docs](https://openmcp-project.github.io/docs).
+SAP Deutschland SE & Co. KG ("SAP", "we", "us") is the controller responsible for processing your personal data when you visit the OpenControlPlane documentation website at [open-control-plane.io](https://open-control-plane.io).
 
 ## Data We Collect
 
@@ -35,7 +35,7 @@ This website uses only **technically necessary cookies** that are required for t
 
 ### GitHub Issues and Contributions
 
-If you submit issues, pull requests, or other contributions through GitHub, GitHub's own privacy policy applies to the data you provide. We process your GitHub username and contribution content to maintain and improve the Open Control Plane project.
+If you submit issues, pull requests, or other contributions through GitHub, GitHub's own privacy policy applies to the data you provide. We process your GitHub username and contribution content to maintain and improve the OpenControlPlane project.
 
 ## Your Rights
 

--- a/src/pages/about/terms-of-use.md
+++ b/src/pages/about/terms-of-use.md
@@ -1,17 +1,17 @@
 ---
 title: Terms of Use
-description: Terms of Use for Open Control Plane
+description: Terms of Use for OpenControlPlane
 ---
 
 # Terms of Use
 
 ## Introduction
 
-This website ([openmcp-project.github.io/docs](https://openmcp-project.github.io/docs)) is maintained by Linux Foundation Europe as part of the Open Control Plane project. By accessing or using this website, you agree to be bound by these Terms of Use. If you do not agree to these terms, please do not use this website.
+This website ([openmcp-project.github.io/docs](https://openmcp-project.github.io/docs)) is maintained by Linux Foundation Europe as part of the OpenControlPlane project. By accessing or using this website, you agree to be bound by these Terms of Use. If you do not agree to these terms, please do not use this website.
 
 ## Trademarks
 
-Open Control Plane and its associated logos and trademarks are trademarks of Linux Foundation Europe. Use of these trademarks must comply with the Linux Foundation Europe [Trademark Usage Guidelines](https://linuxfoundation.eu/policies). You may not use these trademarks without prior written permission, except as permitted by applicable law.
+OpenControlPlane and its associated logos and trademarks are trademarks of Linux Foundation Europe. Use of these trademarks must comply with the Linux Foundation Europe [Trademark Usage Guidelines](https://linuxfoundation.eu/policies). You may not use these trademarks without prior written permission, except as permitted by applicable law.
 
 All other trademarks, service marks, and trade names referenced on this site are the property of their respective owners.
 
@@ -23,7 +23,7 @@ Except where otherwise noted, content on this site is licensed under the [Creati
 
 ### Software
 
-Software source code published by the Open Control Plane project is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0), unless otherwise noted in the respective repository. You may obtain a copy of the license at the link above.
+Software source code published by the OpenControlPlane project is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0), unless otherwise noted in the respective repository. You may obtain a copy of the license at the link above.
 
 ## Disclaimer of Warranties
 
@@ -43,4 +43,4 @@ These Terms of Use are governed by the laws of Belgium, without regard to confli
 
 If any provision of these Terms of Use is found to be unenforceable, the remaining provisions will continue in full force and effect.
 
-If you have questions about these terms, please contact the Open Control Plane project through [GitHub](https://github.com/openmcp-project).
+If you have questions about these terms, please contact the OpenControlPlane project through [GitHub](https://github.com/openmcp-project).

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -242,12 +242,12 @@ export default function Home() {
   }
 
   return (
-    <Layout title={`${siteConfig.title}`} description="Documentation for open control plane">
+    <Layout title={`${siteConfig.title}`} description="Documentation for OpenControlPlane">
       <div className="lp-home">
         <div className="flex-container">
           <div className="main">
             <h1 className="heading">
-              <span className="name clip">open control plane docs</span>
+              <span className="name clip">OpenControlPlane docs</span>
               <span className="text">Give your teams the power to run robust, compliant clouds. Public, private, or Sovereign.</span>
             </h1>
             <div className="container" style={{ padding: "0" }}>
@@ -939,7 +939,7 @@ spec:
             <div className="section-header section-header-right">
               <div className="section-header-content">
                 <h2 className="section-main-title"><i>READY-TO-USE</i> CONTROL PLANES</h2>
-                <p className="section-subtitle">Provision, manage, secure all instances on open control plane platform</p>
+                <p className="section-subtitle">Provision, manage, secure all instances on OpenControlPlane platform</p>
                 {/* Subsection navigation */}
                 <div className="section-nav-dots">
                   <button
@@ -1069,7 +1069,7 @@ spec:
             <div className="section-header">
               <div className="section-header-content">
                 <h2 className="section-main-title">RUNS EVERYWHERE</h2>
-                <p className="section-subtitle">Open Control Plane can be installed wherever Kubernetes is available.</p>
+                <p className="section-subtitle">OpenControlPlane can be installed wherever Kubernetes is available.</p>
                 {/* Subsection navigation */}
                 <div className="section-nav-dots">
                   <button

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -43,7 +43,7 @@ export default function Footer() {
         <div className="ocp-footer__inner">
           <p>
             <strong>Copyright © Linux Foundation Europe.</strong>{' '}
-            Open Control Plane is a project of the Open Component Model Community. For
+            OpenControlPlane is a project of the Open Component Model Community. For
             applicable policies including privacy policy, terms of use and trademark usage
             guidelines, please see{' '}
             <a href="https://linuxfoundation.eu" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects the brand naming from 'Open Control Plane' (spaced) to 'OpenControlPlane' across the documentation site, including the site config, landing page, footer, legal pages, developer docs, and adds a CODEOWNERS file.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
```doc user
Corrected brand naming from 'Open Control Plane' to 'OpenControlPlane' throughout the documentation site.
```