### PR TITLE
fix: update footer to NeoNephos Foundation

### DIFF
--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -43,7 +43,7 @@ export default function Footer() {
         <div className="ocp-footer__inner">
           <p>
             <strong>Copyright © Linux Foundation Europe.</strong>{' '}
-            OpenControlPlane is a project of the Open Component Model Community. For
+            OpenControlPlane is a project of the NeoNephos Foundation. For
             applicable policies including privacy policy, terms of use and trademark usage
             guidelines, please see{' '}
             <a href="https://linuxfoundation.eu" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects the footer copyright notice. Replaces the incorrect "Open Component Model Community" with "NeoNephos Foundation".

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Fix footer copyright notice to reference NeoNephos Foundation.
```