### PR TITLE
docs(serviceproviders): dev guide runtime updates

### DIFF
--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -100,7 +100,6 @@ The service provider template is built with [kubebuilder](https://book.kubebuild
 
 - **api/** includes generated types and their CRDs which the crd manager will install during the `initCommand`.
 - **internal/controller/** contains the `Reconciler` where you implement your domain specific reconcile logic.
-- **pkg/runtime** contains generic reconcilers that handle openMCP specific logic such as cluster access management and provider config updates. You normally should not modify this package. If you encounter any issues, create an issue in the template repository.
 
 If you are new to implementing Kubernetes controllers, consider completing [building a CronJob tutorial](https://book.kubebuilder.io/cronjob-tutorial/cronjob-tutorial.html) before returning to this guide. The rest of this guide highlights the most important steps to create a service provider and the differences compared to a regular Kubernetes controller.
 
@@ -235,7 +234,7 @@ Velero implements this synchronization as follows:
 
 ```go
 // internal/controller/velero_controller.go
-func (r *VeleroReconciler) CreateOrUpdate(ctx context.Context, obj *apiv1alpha1.Velero, pc *apiv1alpha1.ProviderConfig, clusters spruntime.ClusterContext) (ctrl.Result, error) {
+func (r *VeleroReconciler) CreateOrUpdate(ctx context.Context, obj *apiv1alpha1.Velero, pc *apiv1alpha1.ProviderConfig, clusters clusteraccess.ClusterContext) (ctrl.Result, error) {
  ...
  workloadCluster := resources.NewManagedCluster(clusters.WorkloadCluster.Client(), clusters.WorkloadCluster.RESTConfig(), instance.Namespace(obj), resources.WorkloadCluter)
  secret.Configure(workloadCluster, r.PlatformCluster, pc.Spec.ImagePullSecrets, r.PodNamespace)
@@ -277,7 +276,7 @@ Finally, ensure that the synchronized image pull secrets are [referenced in any 
 
 ## Watch Secrets for Changes
 
-If your service provider references secrets on the platform cluster (e.g. image pull secrets configured in the `ProviderConfig`), you may want to automatically trigger reconciliation when those secrets change. The service-provider-runtime provides an optional `SecretWatcher` interface for this purpose.
+If your service provider references secrets on the platform cluster (e.g. image pull secrets configured in the `ProviderConfig`), you may want to automatically trigger reconciliation when those secrets change. The [opencontrolplane-runtime](https://github.com/openmcp-project/opencontrolplane-runtime) provides an optional `serviceprovider.SecretWatcher` interface for this purpose.
 
 When enabled, the runtime watches Kubernetes `Secret` objects in a configured namespace on the platform cluster. Whenever a secret changes, it calls your `IsReferencedSecret` method to determine whether the change is relevant. If it is, all `ServiceProviderAPI` objects are re-enqueued for reconciliation, ensuring that your provider picks up the updated secret data.
 
@@ -295,11 +294,11 @@ This generates:
 
 ### Implement `IsReferencedSecret`
 
-Your reconciler must implement the `SecretWatcher` interface by providing an `IsReferencedSecret` method. This method receives the changed secret and the current `ProviderConfig`, and returns `true` if the secret should trigger reconciliation.
+Your reconciler must implement the `serviceprovider.SecretWatcher` interface by providing an `IsReferencedSecret` method. This method receives the changed secret and the current `ProviderConfig`, and returns `true` if the secret should trigger reconciliation.
 
 ```go
 // IsReferencedSecret returns true if the given secret should trigger
-// reconciliation. See spruntime.SecretWatcher for details.
+// reconciliation. See serviceprovider.SecretWatcher for details.
 func (r *VeleroReconciler) IsReferencedSecret(ctx context.Context, secret *corev1.Secret, pc *apiv1alpha1.ProviderConfig) bool {
     if pc == nil {
         return false
@@ -322,19 +321,18 @@ The `pc` parameter may be `nil` if the `ProviderConfig` has not been loaded yet.
 In your `main.go`, chain `WithSecretNamespace` when building the `SPReconciler`. The namespace should be the pod's own namespace on the platform cluster, which is where secrets like image pull secrets are typically stored:
 
 ```go
-spr := spruntime.NewSPReconciler[*velerosv1alpha1.Velero, *velerosv1alpha1.ProviderConfig](
-    func() *velerosv1alpha1.Velero { return &velerosv1alpha1.Velero{} },
-).
-    WithPlatformCluster(platformCluster).
-    WithOnboardingCluster(onboardingCluster).
-    WithSecretNamespace(podNamespace).
-    WithServiceProviderReconciler(&controller.VeleroReconciler{...}).
+spr := serviceprovider.NewAPIReconcilerBuilder[*velerosv1alpha1.Velero, *velerosv1alpha1.ProviderConfig]().
+    EmpyObjectProvider(func() *velerosv1alpha1.Velero { return &velerosv1alpha1.Velero{} }).
+    PlatformCluster(platformCluster).
+    OnboardingCluster(onboardingCluster).
+    SecretNamespace(podNamespace).
+    Reconciler(&controller.VeleroReconciler{...}).
     // ...
 ```
 
 The watch is only active when both conditions are met:
-1. Your reconciler implements the `SecretWatcher` interface
-2. `WithSecretNamespace` is configured with a non-empty namespace
+1. Your reconciler implements the `serviceprovider.SecretWatcher` interface
+2. `SecretNamespace` is configured with a non-empty namespace
 
 When a referenced secret changes, the runtime lists all `ServiceProviderAPI` objects from the onboarding cluster and enqueues them for reconciliation. This ensures every service instance picks up the latest secret data during its next reconcile cycle.
 
@@ -348,8 +346,8 @@ The template example contains a basic implementation that installs a CRD into th
 
 ```go
 // CreateOrUpdate is called on every add or update event
-func (r *FooServiceReconciler) CreateOrUpdate(ctx context.Context, svcobj *apiv1alpha1.FooService, _ *apiv1alpha1.ProviderConfig, clusters spruntime.ClusterContext) (ctrl.Result, error) {
- spruntime.StatusProgressing(svcobj, "Reconciling", "Reconcile in progress")
+func (r *FooServiceReconciler) CreateOrUpdate(ctx context.Context, svcobj *apiv1alpha1.FooService, _ *apiv1alpha1.ProviderConfig, clusters clusteraccess.ClusterContext) (ctrl.Result, error) {
+ serviceprovider.StatusProgressing(svcobj, "Reconciling", "Reconcile in progress")
  managedObj := &apiextensionsv1.CustomResourceDefinition{
   ObjectMeta: metav1.ObjectMeta{
    Name: "foos.example.domain",
@@ -360,7 +358,7 @@ func (r *FooServiceReconciler) CreateOrUpdate(ctx context.Context, svcobj *apiv1
   return nil
  })
  if err == nil {
-  spruntime.StatusReady(svcobj)
+  serviceprovider.StatusReady(svcobj)
  }
  return ctrl.Result{}, err
 }
@@ -407,9 +405,9 @@ The Kubernetes objects created by Flux from that `HelmRelease` are managed by Fl
 The basic template example deletes the `Foo` CRD:
 
 ```go
-func (r *FooServiceReconciler) Delete(ctx context.Context, obj *apiv1alpha1.FooService, _ *apiv1alpha1.ProviderConfig, clusters spruntime.ClusterContext) (ctrl.Result, error) {
+func (r *FooServiceReconciler) Delete(ctx context.Context, obj *apiv1alpha1.FooService, _ *apiv1alpha1.ProviderConfig, clusters clusteraccess.ClusterContext) (ctrl.Result, error) {
  l := logf.FromContext(ctx)
- spruntime.StatusTerminating(obj)
+ serviceprovider.StatusTerminating(obj)
  managedObj := fooCRD()
  if err := clusters.MCPCluster.Client().Delete(ctx, managedObj); client.IgnoreNotFound(err) != nil {
   l.Error(err, "delete object failed")
@@ -430,16 +428,16 @@ func (r *FooServiceReconciler) Delete(ctx context.Context, obj *apiv1alpha1.FooS
 The template code runs the provider with full admin permissions. Before releasing you provider, restrict its required permissions with the [ClusterAccessReconciler](https://github.com/openmcp-project/openmcp-operator/blob/main/lib/clusteraccess/clusteraccess.go#L103). There are multiple occurrences in the `main.go` service provider setup.
 
 ```go
- spr := spruntime.NewSPReconciler[*fooservicesv1alpha1.FooService, *fooservicesv1alpha1.ProviderConfig](
-  func() *fooservicesv1alpha1.FooService { return &fooservicesv1alpha1.FooService{} },
- ).
-  WithClusterAccessReconciler(clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "FooService").
+ spr := serviceprovider.NewAPIReconcilerBuilder[*fooservicesv1alpha1.FooService, *fooservicesv1alpha1.ProviderConfig]().
+  EmpyObjectProvider(func() *fooservicesv1alpha1.FooService { return &fooservicesv1alpha1.FooService{} }).
+  ClusterAccessReconciler(clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "FooService").
    WithMCPScheme(mcpScheme).
    WithMCPPermissions(adminPermissions).WithMCPRoleRefs([]common.RoleRef{
    {
     Name: "cluster-admin",
     Kind: "ClusterRole",
-   }}))
+   }})).
+   MustBuild()
 ```
 
 ## Taskfile Usage
@@ -513,9 +511,9 @@ And then, during `CreateOrUpdate` or the `Delete` flows, you could call them as 
 
 ```go
 // CreateOrUpdate is called on every add or update event
-func (r *VeleroReconciler) CreateOrUpdate(ctx context.Context, obj *apiv1alpha1.Velero, pc *apiv1alpha1.ProviderConfig, clusters spruntime.ClusterContext) (ctrl.Result, error) {
+func (r *VeleroReconciler) CreateOrUpdate(ctx context.Context, obj *apiv1alpha1.Velero, pc *apiv1alpha1.ProviderConfig, clusters clusteraccess.ClusterContext) (ctrl.Result, error) {
 	l := log.FromContext(ctx)
-	spruntime.StatusProgressing(obj, "Reconciling", "Reconcile in progress")
+	serviceprovider.StatusProgressing(obj, "Reconciling", "Reconcile in progress")
 	err := r.ensureInstanceID(ctx, obj)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -535,7 +533,7 @@ func (r *VeleroReconciler) CreateOrUpdate(ctx context.Context, obj *apiv1alpha1.
 	managedResources := resultsToResources(results)
 	obj.Status.Resources = managedResources
 	if allResourcesReady(managedResources) {
-		spruntime.StatusReady(obj)
+		serviceprovider.StatusReady(obj)
 	}
 	if errRes {
 		return ctrl.Result{}, errors.New("reconciliation result contains errors")


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Updates the service provider dev guide to address the removal of the `spruntime` package in the service provider template.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```