### PR TITLE
docs(users): simplify concepts section

### DIFF
--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -71,7 +71,7 @@ For example, a project named `platform-team` with a workspace `dev` results in:
 - `project-platform-team` for the project
 - `project-platform-team--ws-dev` for the workspace
 
-[Service Providers](../users/concepts/providers.md) install CRDs on the Onboarding Cluster so that all tenants can discover available services.
+[Service Providers](../users/concepts/providers) install CRDs on the Onboarding Cluster so that all tenants can discover available services.
 
 ### Platform Cluster
 

--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -71,7 +71,7 @@ For example, a project named `platform-team` with a workspace `dev` results in:
 - `project-platform-team` for the project
 - `project-platform-team--ws-dev` for the workspace
 
-[Service Providers](../users/concepts/service-provider.md) install CRDs on the Onboarding Cluster so that all tenants can discover available services.
+[Service Providers](../users/concepts/providers.md) install CRDs on the Onboarding Cluster so that all tenants can discover available services.
 
 ### Platform Cluster
 

--- a/docs/users/00-getting-started.md
+++ b/docs/users/00-getting-started.md
@@ -31,7 +31,7 @@ Learn the basics of working with OpenControlPlane:
 Understand the building blocks:
 - **[`ControlPlanes`](./concepts/controlplane)** - Your dedicated Kubernetes API server
 - **[`Projects` & `Workspaces`](./concepts/controlplane)** - Organize teams and environments
-- **[Service Providers](./concepts/service-provider)** - Deploy services like Crossplane or Landscaper
+- **[Service Providers](./concepts/providers)** - Deploy services like Crossplane or Landscaper
 
 ### Ecosystem
 

--- a/docs/users/concepts/cluster-provider.md
+++ b/docs/users/concepts/cluster-provider.md
@@ -1,8 +1,0 @@
----
-sidebar_position: 4
-id: cluster-provider
----
-
-# Cluster Providers
-
-Cluster providers are responsible for the dynamic creation, modification, and deletion of Kubernetes clusters in an OpenControlPlane environment. They conceal certain cluster technologies (e.g., [Gardener](https://gardener.cloud/) and [Kubernetes-in-Docker](https://kind.sigs.k8s.io/)) behind a homogeneous interface. This allows operators to install an OpenControlPlane system in different environments and on various infrastructure providers without having to adjust the other components of the system accordingly.

--- a/docs/users/concepts/controlplane.md
+++ b/docs/users/concepts/controlplane.md
@@ -5,4 +5,11 @@ id: controlplane
 
 # ControlPlanes
 
+<img src="/img/cp2.png" alt="ControlPlane" style={{maxWidth: '200px'}} />
+
 ControlPlanes are at the heart of OpenControlPlane. Simply put, they are lightweight Kubernetes clusters that store the desired state and current status of various resources. All resources follow the Kubernetes Resource Model (KRM), allowing infrastructure resources, deployments, etc., to be managed with common Kubernetes tools like kubectl, kustomize, Helm, Flux, ArgoCD, and so on.
+
+- **End users** create and manage ControlPlanes to deploy their workloads. → [Getting started](/users/getting-started)
+- **Operators** configure which services and cluster providers are available. → [Operator guide](/operators/overview)
+
+**CRD Reference:** [ManagedControlPlaneV2](/reference/core/controlplane)

--- a/docs/users/concepts/controlplane.md
+++ b/docs/users/concepts/controlplane.md
@@ -7,9 +7,9 @@ id: controlplane
 
 <img src="/img/cp2.png" alt="ControlPlane" style={{maxWidth: '200px'}} />
 
-ControlPlanes are at the heart of OpenControlPlane. Simply put, they are lightweight Kubernetes clusters that store the desired state and current status of various resources. All resources follow the Kubernetes Resource Model (KRM), allowing infrastructure resources, deployments, etc., to be managed with common Kubernetes tools like kubectl, kustomize, Helm, Flux, ArgoCD, and so on.
+`ControlPlanes` are at the heart of OpenControlPlane. Simply put, they are lightweight Kubernetes clusters that store the desired state and current status of various resources. All resources follow the Kubernetes Resource Model (KRM), allowing infrastructure resources, deployments, etc., to be managed with common Kubernetes tools like kubectl, kustomize, Helm, Flux, ArgoCD, and so on.
 
-- **End users** create and manage ControlPlanes to deploy their workloads. → [Getting started](/users/getting-started)
-- **Operators** configure which services and cluster providers are available. → [Operator guide](/operators/overview)
+- **End users** create and manage `ControlPlanes` to deploy their custom resources. → [Getting started](/users/getting-started)
+- **Platform Owners** configure which services and cluster providers are available. → [Platform Owner guide](/operators/overview)
 
-**CRD Reference:** [ManagedControlPlaneV2](/reference/core/controlplane)
+**CRD Reference:** [`ControlPlane`](/reference/core/controlplane)

--- a/docs/users/concepts/overview.md
+++ b/docs/users/concepts/overview.md
@@ -30,6 +30,6 @@ How OpenControlPlane organizes teams and their `ControlPlanes`. Projects group `
 
 The three provider types that extend an OpenControlPlane environment: **Service Providers** add capabilities to individual `ControlPlanes`, **Platform Services** add system-wide infrastructure, and **Cluster Providers** manage the underlying Kubernetes clusters.
 
-**→** [Operator guide](/operators/overview) · [Developer guide](/developers/overview) · [Contribute](https://github.com/openmcp-project/community)
+**→** [Operator guide](/operators/overview) · [Developer guide](/developers/overview) · [Contribute](/community/overview)
 
 <div style={{clear: 'both'}} />

--- a/docs/users/concepts/overview.md
+++ b/docs/users/concepts/overview.md
@@ -8,19 +8,19 @@ slug: /users/concepts
 
 This section explains the core building blocks of OpenControlPlane. Reading through these pages will give you a solid mental model before diving into the guides.
 
-## [Control Planes](./controlplane.md)
+## [`ControlPlanes`](./controlplane.md)
 
 <img src="/img/cp2.png" alt="ControlPlane" style={{maxWidth: '80px', float: 'right', marginLeft: '16px'}} />
 
-The central resource in OpenControlPlane. A Managed Control Plane is a lightweight Kubernetes cluster that stores the desired state of your resources — managed through standard Kubernetes tooling.
+The central resource in OpenControlPlane. A `ControlPlane` is a lightweight Kubernetes cluster that stores the desired state of your resources — managed through standard Kubernetes tooling.
 
 **→** [End user guide](/users/getting-started) · [CRD reference](/reference/core/controlplane)
 
 <div style={{clear: 'both'}} />
 
-## [Projects and Workspaces](./projects-and-workspaces.md)
+## [`Projects` and `Workspaces`](./projects-and-workspaces.md)
 
-How OpenControlPlane organizes teams and their control planes. Projects group control planes by team or business unit; Workspaces represent environments like `dev`, `staging`, or `prod`.
+How OpenControlPlane organizes teams and their `ControlPlanes`. Projects group `ControlPlanes` by team or business unit; Workspaces represent environments like `dev`, `staging`, or `prod`.
 
 **→** [Project CRD](/reference/core/project) · [Workspace CRD](/reference/core/workspace)
 
@@ -28,7 +28,7 @@ How OpenControlPlane organizes teams and their control planes. Projects group co
 
 <img src="/img/provider_types.png" alt="Provider types" style={{maxWidth: '160px', float: 'right', marginLeft: '16px'}} />
 
-The three provider types that extend an OpenControlPlane environment: **Service Providers** add capabilities to individual control planes, **Platform Services** add system-wide infrastructure, and **Cluster Providers** manage the underlying Kubernetes clusters.
+The three provider types that extend an OpenControlPlane environment: **Service Providers** add capabilities to individual `ControlPlanes`, **Platform Services** add system-wide infrastructure, and **Cluster Providers** manage the underlying Kubernetes clusters.
 
 **→** [Operator guide](/operators/overview) · [Developer guide](/developers/overview) · [Contribute](https://github.com/openmcp-project/community)
 

--- a/docs/users/concepts/overview.md
+++ b/docs/users/concepts/overview.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 0
+id: concepts-overview
+slug: /users/concepts
+---
+
+# Overview
+
+This section explains the core building blocks of OpenControlPlane. Reading through these pages will give you a solid mental model before diving into the guides.
+
+## [Control Planes](./controlplane.md)
+
+<img src="/img/cp2.png" alt="ControlPlane" style={{maxWidth: '80px', float: 'right', marginLeft: '16px'}} />
+
+The central resource in OpenControlPlane. A Managed Control Plane is a lightweight Kubernetes cluster that stores the desired state of your resources — managed through standard Kubernetes tooling.
+
+**→** [End user guide](/users/getting-started) · [CRD reference](/reference/core/controlplane)
+
+<div style={{clear: 'both'}} />
+
+## [Projects and Workspaces](./projects-and-workspaces.md)
+
+How OpenControlPlane organizes teams and their control planes. Projects group control planes by team or business unit; Workspaces represent environments like `dev`, `staging`, or `prod`.
+
+**→** [Project CRD](/reference/core/project) · [Workspace CRD](/reference/core/workspace)
+
+## [Providers](./providers.md)
+
+<img src="/img/provider_types.png" alt="Provider types" style={{maxWidth: '160px', float: 'right', marginLeft: '16px'}} />
+
+The three provider types that extend an OpenControlPlane environment: **Service Providers** add capabilities to individual control planes, **Platform Services** add system-wide infrastructure, and **Cluster Providers** manage the underlying Kubernetes clusters.
+
+**→** [Operator guide](/operators/overview) · [Developer guide](/developers/overview) · [Contribute](https://github.com/openmcp-project/community)
+
+<div style={{clear: 'both'}} />

--- a/docs/users/concepts/platform-service.md
+++ b/docs/users/concepts/platform-service.md
@@ -1,8 +1,0 @@
----
-sidebar_position: 5
-id: platform-service
----
-
-# Platform Services
-
-Platform services add functionality to an OpenControlPlane environment (not ControlPlanes). Examples include network services (Gateway API, Ingress), audit logs, billing, grouping of ControlPlanes, and system-wide policies. They are installed and configured by the platform owner and apply to the entire system.

--- a/docs/users/concepts/projects-and-workspaces.md
+++ b/docs/users/concepts/projects-and-workspaces.md
@@ -5,17 +5,17 @@ id: projects-and-workspaces
 
 # Projects and Workspaces
 
-Projects and Workspaces are the way OpenControlPlane organizes teams and their ControlPlanes.
+Projects and Workspaces are the way OpenControlPlane organizes teams and their `ControlPlanes`.
 
-- A **Project** is a logical grouping of ControlPlanes that belong to a team or business unit. It provides a namespace boundary and access control scope.
-- A **Workspace** is a named environment within a Project — for example `dev`, `staging`, or `prod`. Each Workspace can contain multiple ControlPlanes.
+- A **`Project`** is a logical grouping of `ControlPlanes` that belong to a team or business unit. It provides a namespace boundary and access control scope.
+- A **`Workspace`** is a named environment within a Project — for example `dev`, `staging`, or `prod`. Each Workspace can contain multiple `ControlPlanes`.
 
 This gives teams a clear structure to organize their control planes by environment or purpose.
 
-- **End users** create ControlPlanes within their team's Project and Workspace. → [Getting started](/users/getting-started)
+- **End users** create `ControlPlanes` within their team's Project and Workspace. → [Getting started](/users/getting-started)
 - **Operators** set up Projects and Workspaces as part of platform onboarding. → [Operator guide](/operators/overview)
 
-**CRD Reference:** [Project](/reference/core/project) · [Workspace](/reference/core/workspace)
+**CRD Reference:** [`Project`](/reference/core/project) · [`Workspace`](/reference/core/workspace)
 
 :::note
 Full documentation for Projects and Workspaces is coming soon. User management via Projects and Workspaces will be covered in the [Production Setup](/operators/production-setup/production-overview) section.

--- a/docs/users/concepts/projects-and-workspaces.md
+++ b/docs/users/concepts/projects-and-workspaces.md
@@ -12,6 +12,11 @@ Projects and Workspaces are the way OpenControlPlane organizes teams and their C
 
 This gives teams a clear structure to organize their control planes by environment or purpose.
 
+- **End users** create ControlPlanes within their team's Project and Workspace. → [Getting started](/users/getting-started)
+- **Operators** set up Projects and Workspaces as part of platform onboarding. → [Operator guide](/operators/overview)
+
+**CRD Reference:** [Project](/reference/core/project) · [Workspace](/reference/core/workspace)
+
 :::note
 Full documentation for Projects and Workspaces is coming soon. User management via Projects and Workspaces will be covered in the [Production Setup](/operators/production-setup/production-overview) section.
 :::

--- a/docs/users/concepts/providers.md
+++ b/docs/users/concepts/providers.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 3
+id: providers
+slug: /users/concepts/providers
+---
+
+# Plug & Play
+
+Providers extend an OpenControlPlane environment with additional functionality. There are three distinct types, each operating at a different scope. All provider types are open for community contributions — if you have a use case not yet covered, [we'd love to hear from you](https://github.com/openmcp-project/community).
+
+![Overview of provider types in OpenControlPlane](/img/provider_types.png)
+
+## Service Providers
+
+<img src="/img/platform/tower.png" alt="ServiceProvider" style={{maxWidth: '80px', float: 'right', marginLeft: '16px'}} />
+
+Service Providers add functionality to individual **ControlPlanes** — examples include cloud provider APIs, GitOps tooling, policies, or backup and restore.
+
+- **Operators** install and configure which service providers are available in the environment.
+- **End users** choose which of those providers to activate for their own ControlPlane.
+
+**CRD Reference:** [ServiceProvider](/reference/operator/providers/serviceprovider) · [Available services](/reference/overview#service-providers)
+
+**Developer guide:** [Build a Service Provider](/developers/overview)
+
+<div style={{clear: 'both'}} />
+
+## Platform Services
+
+<img src="/img/platform/main.png" alt="PlatformService" style={{maxWidth: '80px', float: 'right', marginLeft: '16px'}} />
+
+Platform Services add functionality to the **OpenControlPlane environment as a whole** — not to individual ControlPlanes. Examples include network services (Gateway API, Ingress), audit logs, billing, and system-wide policies.
+
+- **Operators** install and configure platform services; they apply to the entire system.
+- **End users** benefit from platform services automatically — there is nothing to activate or configure.
+
+**CRD Reference:** [PlatformService](/reference/operator/providers/platformservice)
+
+**Operator guide:** [Configure platform services](/operators/overview)
+
+<div style={{clear: 'both'}} />
+
+## Cluster Providers
+
+<img src="/img/platform/hangar_gardener.png" alt="ClusterProvider" style={{maxWidth: '80px', float: 'right', marginLeft: '16px'}} />
+
+Cluster Providers handle the dynamic creation, modification, and deletion of Kubernetes clusters. They abstract away specific cluster technologies (e.g., [Gardener](https://gardener.cloud/) and [Kubernetes-in-Docker](https://kind.sigs.k8s.io/)) behind a homogeneous interface.
+
+- **Operators** select and configure the cluster provider that matches their target infrastructure.
+- **End users** are not exposed to this layer — cluster lifecycle is handled transparently when a ControlPlane is created or deleted.
+
+**CRD Reference:** [ClusterProvider](/reference/operator/providers/clusterprovider)
+
+**Developer guide:** [Build a Cluster Provider](/developers/overview)
+
+<div style={{clear: 'both'}} />

--- a/docs/users/concepts/providers.md
+++ b/docs/users/concepts/providers.md
@@ -6,7 +6,7 @@ slug: /users/concepts/providers
 
 # Plug & Play
 
-Providers extend an OpenControlPlane environment with additional functionality. There are three distinct types, each operating at a different scope. All provider types are open for community contributions — if you have a use case not yet covered, [we'd love to hear from you](https://github.com/openmcp-project/community).
+Providers extend an OpenControlPlane environment with additional functionality. There are three distinct types, each operating at a different scope. All provider types are open for community contributions - if you have a use case not yet covered, [we'd love to hear from you](https://github.com/orgs/openmcp-project/discussions).
 
 ![Overview of provider types in OpenControlPlane](/img/provider_types.png)
 
@@ -14,14 +14,14 @@ Providers extend an OpenControlPlane environment with additional functionality. 
 
 <img src="/img/platform/tower.png" alt="ServiceProvider" style={{maxWidth: '80px', float: 'right', marginLeft: '16px'}} />
 
-Service Providers add functionality to individual **ControlPlanes** — examples include cloud provider APIs, GitOps tooling, policies, or backup and restore.
+Service Providers add functionality to individual **`ControlPlanes`** — examples include cloud provider APIs, GitOps tooling, policies, or backup and restore.
 
-- **Operators** install and configure which service providers are available in the environment.
-- **End users** choose which of those providers to activate for their own ControlPlane.
+- **Platform Owners** install and configure which service providers are available in the environment.
+- **End users** choose which of those providers to activate for their own `ControlPlane`.
 
 **CRD Reference:** [ServiceProvider](/reference/operator/providers/serviceprovider) · [Available services](/reference/overview#service-providers)
 
-**Developer guide:** [Build a Service Provider](/developers/overview)
+**Developer guide:** [Build a Service Provider](/developers/serviceprovider/develop)
 
 <div style={{clear: 'both'}} />
 
@@ -29,14 +29,14 @@ Service Providers add functionality to individual **ControlPlanes** — examples
 
 <img src="/img/platform/main.png" alt="PlatformService" style={{maxWidth: '80px', float: 'right', marginLeft: '16px'}} />
 
-Platform Services add functionality to the **OpenControlPlane environment as a whole** — not to individual ControlPlanes. Examples include network services (Gateway API, Ingress), audit logs, billing, and system-wide policies.
+Platform Services add functionality to the **OpenControlPlane environment as a whole** — not to individual `ControlPlanes`. Examples include network services (Gateway API, Ingress), audit logs, billing, and system-wide policies.
 
-- **Operators** install and configure platform services; they apply to the entire system.
-- **End users** benefit from platform services automatically — there is nothing to activate or configure.
+- **Platform Owners** install and configure platform services; they apply to the entire system.
+- **End users** benefit from platform services automatically - there is nothing to activate or configure.
 
 **CRD Reference:** [PlatformService](/reference/operator/providers/platformservice)
 
-**Operator guide:** [Configure platform services](/operators/overview)
+**Operator guide:** [Configure platform services](/developers/overview)
 
 <div style={{clear: 'both'}} />
 
@@ -46,8 +46,8 @@ Platform Services add functionality to the **OpenControlPlane environment as a w
 
 Cluster Providers handle the dynamic creation, modification, and deletion of Kubernetes clusters. They abstract away specific cluster technologies (e.g., [Gardener](https://gardener.cloud/) and [Kubernetes-in-Docker](https://kind.sigs.k8s.io/)) behind a homogeneous interface.
 
-- **Operators** select and configure the cluster provider that matches their target infrastructure.
-- **End users** are not exposed to this layer — cluster lifecycle is handled transparently when a ControlPlane is created or deleted.
+- **Platform Owners** select and configure the cluster provider that matches their target infrastructure.
+- **End users** are not exposed to this layer - cluster lifecycle is handled transparently when a `ControlPlane` is created or deleted.
 
 **CRD Reference:** [ClusterProvider](/reference/operator/providers/clusterprovider)
 

--- a/docs/users/concepts/service-provider.md
+++ b/docs/users/concepts/service-provider.md
@@ -1,8 +1,0 @@
----
-sidebar_position: 3
-id: service-provider
----
-
-# Service Providers
-
-Without service providers, ControlPlanes are of little use. They add functionality such as cloud provider APIs, GitOps, policies, or backup and restore to ControlPlanes. The operators of an OpenControlPlane environment decide which service providers are available to end users. The end users can then activate them for their ControlPlanes.

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -160,7 +160,7 @@ The chart source, image pull secret, and Helm values are configured cluster-wide
 Congratulations! You have a working ControlPlane with managed services. Here's what you can explore next:
 
 - **[What is a ControlPlane?](../concepts/controlplane.md)** — Deeper understanding of ControlPlanes
-- **[Service Providers](../concepts/service-provider.md)** — How managed services work
+- **[Service Providers](../concepts/providers.md)** — How managed services work
 - **[Crossplane Service Provider](https://github.com/openmcp-project/service-provider-crossplane)** — Manage cloud infrastructure
 - **[Landscaper Service Provider](https://github.com/openmcp-project/service-provider-landscaper)** — Orchestrate complex workloads
 - **[OCM Service Provider](https://github.com/open-component-model/service-provider-ocm)** — Deliver and deploy software with the Open Component Model

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -159,8 +159,8 @@ The chart source, image pull secret, and Helm values are configured cluster-wide
 
 Congratulations! You have a working ControlPlane with managed services. Here's what you can explore next:
 
-- **[What is a ControlPlane?](../concepts/controlplane.md)** — Deeper understanding of ControlPlanes
-- **[Service Providers](../concepts/providers.md)** — How managed services work
+- **[What is a ControlPlane?](../concepts/controlplane)** — Deeper understanding of ControlPlanes
+- **[Service Providers](../concepts/providers)** — How managed services work
 - **[Crossplane Service Provider](https://github.com/openmcp-project/service-provider-crossplane)** — Manage cloud infrastructure
 - **[Landscaper Service Provider](https://github.com/openmcp-project/service-provider-landscaper)** — Orchestrate complex workloads
 - **[OCM Service Provider](https://github.com/open-component-model/service-provider-ocm)** — Deliver and deploy software with the Open Component Model


### PR DESCRIPTION
**What this PR does / why we need it**:
Merges the three separate provider concept pages (service-provider, platform-service, cluster-provider) into a single `providers.md`. Adds a concepts `overview.md` as the section landing page. Fixes broken links caused by the removed files.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```doc user
Simplified users/concepts section: merged provider pages into one and added a section overview.
```