### PR TITLE
feat(ui): make CRD browser button a teal gradient pill

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2511,24 +2511,51 @@ body[class*="docs-doc-id-reference"] .row {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--teal-7);
+  padding: 7px 16px;
+  border-radius: 100px;
+  background: linear-gradient(135deg, var(--teal-6) 0%, var(--teal-7) 100%);
+  color: #ffffff !important;
   text-decoration: none;
   font-weight: 600;
-  font-size: 0.9rem;
-  transition: gap 0.2s ease;
+  font-size: 0.85rem;
+  letter-spacing: 0.2px;
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--teal-7) 35%, transparent);
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.reference-link::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0) 60%);
+  pointer-events: none;
 }
 
 .reference-link:hover {
   gap: 10px;
-  color: var(--teal-6);
+  background: linear-gradient(135deg, var(--teal-5) 0%, var(--teal-6) 100%);
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--teal-6) 45%, transparent);
+  transform: translateY(-1px);
+  color: #ffffff !important;
+}
+
+.reference-link:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--teal-7) 30%, transparent);
 }
 
 [data-theme='dark'] .reference-link {
-  color: var(--teal-4);
+  background: linear-gradient(135deg, var(--teal-7) 0%, var(--teal-10) 100%);
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--teal-6) 30%, transparent);
+  color: var(--teal-2) !important;
 }
 
 [data-theme='dark'] .reference-link:hover {
-  color: var(--teal-2);
+  background: linear-gradient(135deg, var(--teal-6) 0%, var(--teal-7) 100%);
+  box-shadow: 0 4px 18px color-mix(in srgb, var(--teal-6) 40%, transparent);
+  color: #ffffff !important;
 }
 
 


### PR DESCRIPTION
## Summary

Transforms the `.reference-link` "View CRD →" button from a plain teal text link into a styled pill button using the project's teal color palette.

- Pill shape with `border-radius: 100px`
- Teal 6→7 gradient background (light mode), Teal 7→10 (dark mode)
- Subtle shimmer overlay via `::before` pseudo-element
- Teal-tinted box shadow that deepens on hover
- Lift animation (`translateY(-1px)`) on hover
- Arrow gap animation retained
- Featured card variant (dark glass style on teal hero cards) unchanged

## Test plan

- [ ] Check `/reference/overview` — all "View CRD →" buttons render as teal pills
- [ ] Check dark mode — buttons use the darker teal gradient
- [ ] Check featured cards — glass-style button on hero cards is unaffected