### PR TITLE
docs: rename OpenMCP to OpenControlPlane

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -41,7 +41,7 @@
 - [x] End user getting started: Prerequisites (platform installed)
 - [x] End user getting started: authentication/authorization
 - [x] End user getting started: pictures (hierarchy diagram)
-- [x] Double check no openMCP → OpenControlPlane (cleanup legacy naming)
+- [x] Double check no OpenMCP → OpenControlPlane (cleanup legacy naming)
 - [x] SIGs mit rein (include SIGs)
 - [x] Community seite - how to participate
 - [x] Contributing: Wie kann ich partizipieren (How can I participate) - an der community

--- a/adrs/authors.yml
+++ b/adrs/authors.yml
@@ -1,19 +1,19 @@
 ValentinGerlach:
   name: Valentin Gerlach
-  title: openMCP Contributor
+  title: OpenControlPlane Contributor
   url: https://github.com/ValentinGerlach
   image_url: /img/authors/ValentinGerlach.png
   socials:
     github: ValentinGerlach
 ReneSchuenemann:
   name: Rene Schünemann
-  title: openMCP Contributor
+  title: OpenControlPlane Contributor
   url: https://github.com/reshnm
   socials:
     github: reshnm
 MaximilianTechritz:
   name: Maximilian Techritz
-  title: openMCP Contributor
+  title: OpenControlPlane Contributor
   url: https://github.com/maximiliantech
   socials:
     github: maximiliantech

--- a/docs/developers/clusterprovider/01-deployment.mdx
+++ b/docs/developers/clusterprovider/01-deployment.mdx
@@ -70,7 +70,7 @@ The following environment variables can be expected to be set:
 
 #### Customizations
 
-While it is possible to customize some aspects of how the provider binary is executed, such as adding additional environment variables, overwriting the subcommands, adding additional arguments, etc., this should only be done in exceptional cases to keep the complexity of setting up an openMCP landscape as low as possible.
+While it is possible to customize some aspects of how the provider binary is executed, such as adding additional environment variables, overwriting the subcommands, adding additional arguments, etc., this should only be done in exceptional cases to keep the complexity of setting up an OpenControlPlane landscape as low as possible.
 
 ### Configuration
 

--- a/docs/developers/serviceprovider/01-design.mdx
+++ b/docs/developers/serviceprovider/01-design.mdx
@@ -120,7 +120,7 @@ graph TD
 
     %% Platform Cluster
     subgraph PlatformCluster
-        SPO[openMCP-operator]
+        SPO[openmcp-operator]
         SP[ServiceProvider]
         SPC[ServiceProviderConfig]
     end

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -70,7 +70,7 @@ git submodule update --init --recursive
 task test-e2e
 ```
 
-This test bootstraps a complete local openMCP installation with all required components, including:
+This test bootstraps a complete local OpenControlPlane installation with all required components, including:
 
 - **The platform cluster** where your service provider is managed by the [openmcp-operator](https://github.com/openmcp-project/openmcp-operator)
 - **The onboarding cluster** where end users request the domain service you provider offers.
@@ -338,7 +338,7 @@ When a referenced secret changes, the runtime lists all `ServiceProviderAPI` obj
 
 ## Edit the ServiceProviderReconciler
 
-Your `Reconciler` must implement two methods: `CreateOrUpdate` and `Delete`. The template sets up your reconciler together with the generic reconciler from `pkg/runtime`, which handles openMCP-specifics (cluster access, config updates, etc.).
+Your `Reconciler` must implement two methods: `CreateOrUpdate` and `Delete`. The template sets up your reconciler together with the generic reconciler from `pkg/runtime`, which handles OpenControlPlane-specifics (cluster access, config updates, etc.).
 
 ### CreateOrUpdate Operation
 
@@ -442,7 +442,7 @@ The template code runs the provider with full admin permissions. Before releasin
 
 ## Taskfile Usage
 
-OpenMCP controllers use `task` instead of `make` to generate code, build your controller image, etc. The most important developer commands are:
+OpenControlPlane controllers use `task` instead of `make` to generate code, build your controller image, etc. The most important developer commands are:
 
 - **task generate** to regenerate code after API changes
 - **task build:img:build-test** to build an image for local testing

--- a/docs/developers/serviceprovider/03-debugging.mdx
+++ b/docs/developers/serviceprovider/03-debugging.mdx
@@ -5,19 +5,19 @@ id: debugging
 
 # Debug
 
-This guide helps you run and debug your service provider during local development. It assumes you are developing based on the [service-provider-template](https://github.com/openmcp-project/service-provider-template) and running a local OpenMCP installation via [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind).
+This guide helps you run and debug your service provider during local development. It assumes you are developing based on the [service-provider-template](https://github.com/openmcp-project/service-provider-template) and running a local OpenControlPlane installation via [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind).
 
 ## Local Development Setup
 
 ### Deploy a Local Installation
 
-Use the `local-dev.sh` script from [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind) to spin up a full local OpenMCP environment:
+Use the `local-dev.sh` script from [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind) to spin up a full local OpenControlPlane environment:
 
 ```bash
 ./hack/local-dev.sh deploy
 ```
 
-This creates a KinD-based Platform cluster with the OpenMCP operator, cluster provider, and any configured service providers.
+This creates a KinD-based Platform cluster with the OpenControlPlane operator, cluster provider, and any configured service providers.
 
 To tear everything down and start fresh:
 

--- a/docs/developers/serviceprovider/05-deployment.mdx
+++ b/docs/developers/serviceprovider/05-deployment.mdx
@@ -70,7 +70,7 @@ The following environment variables can be expected to be set:
 
 #### Customizations
 
-While it is possible to customize some aspects of how the provider binary is executed, such as adding additional environment variables, overwriting the subcommands, adding additional arguments, etc., this should only be done in exceptional cases to keep the complexity of setting up an openMCP landscape as low as possible.
+While it is possible to customize some aspects of how the provider binary is executed, such as adding additional environment variables, overwriting the subcommands, adding additional arguments, etc., this should only be done in exceptional cases to keep the complexity of setting up an OpenControlPlane landscape as low as possible.
 
 ### Configuration
 

--- a/docs/operators/production-setup/00-overview.md
+++ b/docs/operators/production-setup/00-overview.md
@@ -29,7 +29,7 @@ The bootstrapper sets up a GitOps process: the desired state of your landscape i
 ```mermaid
 flowchart TD
     subgraph OCI Registry
-        A[openMCP Root OCM Component]
+        A[OpenControlPlane Root OCM Component]
     end
 
     subgraph GitRepo[Git Repository]

--- a/docs/operators/production-setup/01-gardener-provider.md
+++ b/docs/operators/production-setup/01-gardener-provider.md
@@ -37,7 +37,7 @@ mkdir kubeconfigs
 
 ## Create a Gardener Shoot for the Platform Cluster
 
-openMCP requires a running Kubernetes cluster that acts as the platform cluster.
+OpenControlPlane requires a running Kubernetes cluster that acts as the platform cluster.
 The platform cluster hosts the openmcp-operator and all service providers, cluster providers and platform services.
 In this example, we will create a Gardener Shoot cluster that acts as the platform cluster. See the [Gardener documentation](https://gardener.cloud/docs/getting-started/shoots/) for more information on how to create a Gardener Shoot cluster.
 
@@ -92,7 +92,7 @@ Download the admin kubeconfig of the `platform` Shoot cluster using the script c
 
 Replace `<your-org>` and `<your-repo>` with your Git organization and repository name.
 The environment can be set to the logical environment name (e.g. `dev`, `prod`, `live-eu-west`) that will be used in the Git repository to separate different environments.
-The branch can be set to the desired branch name in the Git repository that will be used to store the desired state of the openMCP landscape.
+The branch can be set to the desired branch name in the Git repository that will be used to store the desired state of the OpenControlPlane landscape.
 
 Get the latest version of the `github.com/openmcp/openmcp` root component:
 
@@ -201,7 +201,7 @@ flux-system   flux-system   3m15s   False   Source artifact not found, retrying 
 
 This error is also expected as the GitRepository does not exist yet. The `openmcp-bootstrapper` will create the GitRepository in the next step.
 
-## Run the `openmcp-bootstrapper` CLI tool to deploy openMCP to the Kind cluster
+## Run the `openmcp-bootstrapper` CLI tool to deploy OpenControlPlane to the Kind cluster
 
 Update the bootstrapping configuration file (bootstrapper-config.yaml) to include the Gardener cluster provider and the openmcp-operator configuration.
 
@@ -519,7 +519,7 @@ Replace also `<kubernetes-version>` with the desired Kubernetes version (e.g. `1
 Please adjust the shoot configuration based on your specific needs, e.g. change `Evaluation` to `Production` as purpose, if you are planning to use the ControlPlane for productive purposes. For all the details reg. Shoot configuration, please consult the respective Gardener documentation.
 :::
 
-Now run the `openmcp-bootstrapper` CLI tool to update the Git repository and deploy openMCP to the `platform` Gardener Shoot cluster:
+Now run the `openmcp-bootstrapper` CLI tool to update the Git repository and deploy OpenControlPlane to the `platform` Gardener Shoot cluster:
 
 ```shell
 docker run --rm -v ./config:/config -v ./kubeconfigs:/kubeconfigs ghcr.io/openmcp-project/images/openmcp-bootstrapper:${OPENMCP_BOOTSTRAPPER_VERSION} manage-deployment-repo --git-config /config/git-config.yaml --kubeconfig /kubeconfigs/platform.kubeconfig --extra-manifest-dir /config/extra-manifests /config/bootstrapper-config.yaml
@@ -551,7 +551,7 @@ Info: Applying Kustomization manifest: default/bootstrap
 
 ## Inspect the Git repository
 
-The desired state of the openMCP landscape has now been created in the Git repository and should look similar to the following structure:
+The desired state of the OpenControlPlane landscape has now been created in the Git repository and should look similar to the following structure:
 
 ```shell
 .
@@ -599,5 +599,5 @@ The desired state of the openMCP landscape has now been created in the Git repos
     └── root-kustomization.yaml
 ```
 
-The `envs/<environment-name>` folder contains the Kustomization files that are used by FluxCD to deploy openMCP to the platform cluster.
+The `envs/<environment-name>` folder contains the Kustomization files that are used by FluxCD to deploy OpenControlPlane to the platform cluster.
 The `resources` folder contains the base resources that are used by the Kustomization files in the `envs/<environment-name>` folder.

--- a/docs/operators/production-setup/02-verify-setup.md
+++ b/docs/operators/production-setup/02-verify-setup.md
@@ -32,9 +32,9 @@ kubectl --kubeconfig ./kubeconfigs/platform.kubeconfig get kustomizations.kustom
 
 You should see the `flux-system` and `bootstrap` Kustomizations in Ready state.
 
-## Inspect the deployed openMCP components
+## Inspect the deployed OpenControlPlane components
 
-Check the deployed openMCP components:
+Check the deployed OpenControlPlane components:
 
 ```shell
 kubectl --kubeconfig ./kubeconfigs/platform.kubeconfig get pods -n openmcp-system

--- a/src/pages/about/terms-of-use.md
+++ b/src/pages/about/terms-of-use.md
@@ -7,7 +7,7 @@ description: Terms of Use for OpenControlPlane
 
 ## Introduction
 
-This website ([openmcp-project.github.io/docs](https://openmcp-project.github.io/docs)) is maintained by Linux Foundation Europe as part of the OpenControlPlane project. By accessing or using this website, you agree to be bound by these Terms of Use. If you do not agree to these terms, please do not use this website.
+This website ([open-control-plane.io](https://open-control-plane.io/)) is maintained by Linux Foundation Europe as part of the OpenControlPlane project. By accessing or using this website, you agree to be bound by these Terms of Use. If you do not agree to these terms, please do not use this website.
 
 ## Trademarks
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Renames the brand text "OpenMCP" / "openMCP" to the official name "OpenControlPlane" across user-facing documentation. Technical identifiers tied to the codebase are preserved verbatim:

- `openmcp-project` GitHub org
- `openmcp.cloud` Kubernetes API group (and all subgroups)
- `openmcp-system` namespace
- `openmcp-operator`, `openmcp-bootstrapper` component names
- `OPENMCP_BOOTSTRAPPER_VERSION` env var
- Upstream Go types `setup.OpenMCPSetup` / `setup.OpenMCPOperatorSetup` referenced from `github.com/openmcp-project/openmcp-testing` in `docs/developers/serviceprovider/04-testing.mdx` — these are real exported identifiers in the upstream package; update once it is renamed upstream.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Follows the earlier rename in #119 (MCP/ManagedControlPlane → ControlPlane). The `BACKLOG.md` checklist item tracking this rename has been ticked off.

**Release note**:
```doc user
Documentation now uses the official project name "OpenControlPlane" in place of "OpenMCP".
```