### PR TITLE
docs(serviceprovider): document deletion blocking behaviour

### DIFF
--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -124,7 +124,7 @@ For example, Velero allows the user to choose a version and which plugins to ins
 apiVersion: velero.services.openmcp.cloud/v1alpha1
 kind: Velero
 metadata:
-  name: test-mcp
+  name: test-controlplane
 spec:
   version: "v1.17.1"
   plugins:

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -425,14 +425,13 @@ func (r *FooServiceReconciler) Delete(ctx context.Context, obj *apiv1alpha1.FooS
 
 ### Block deletion while user resources exist
 
-A naive `Delete` implementation removes the domain CRDs from the `ControlPlane` as soon as the user deletes the `ServiceProviderAPI`. Domain services such as Flux, Crossplane, or ESO install CRDs (e.g. `GitRepository`, `Bucket`, `ExternalSecret`) into the `ControlPlane`, and end users typically create custom resources of those CRDs. Removing the CRDs while user instances still exist orphans those resources in the cluster and can leave external systems (object storage, git repositories, secrets in vaults) escaping platform control.
+A naive `Delete` implementation removes the domain CRDs from the `ControlPlane` as soon as the user requests deletion of the service via the Onboarding cluster. Services such as Flux, Crossplane, or ESO install CRDs (e.g. `GitRepository`, `Bucket`, `ExternalSecret`) into the `ControlPlane`, and end users typically create custom resources of those CRDs. Removing the CRDs while user instances still exist orphans those resources in the cluster and can leave external systems (object storage, git repositories, secrets in vaults) escaping platform control.
 
 Quality criterion [Deletion behaviour](./quality-criteria#1-deletion-behaviour) requires the service provider to block deletion in this case. The expected flow inside `Delete`:
 
-1. Before removing any managed resource, list the domain CRs on `clusters.MCPCluster` for each kind the provider installs.
-2. If any instance exists, do **not** delete the managed resources. Set `Status.Phase = Terminating` and surface a `DeletionBlocked` condition (`type: DeletionBlocked`, `status: True`, `reason: UserResourcesPresent`, `message:` naming the offending kinds and counts) so the end user can see what to clean up.
-3. Return `ctrl.Result{RequeueAfter: ...}` so the controller re-checks once the user has cleaned up.
-4. Only when no user CRs remain, proceed with the existing teardown (delete CRDs, namespaces, workloads, etc.).
+1. Look up the user's custom resources on `clusters.MCPCluster` for the CRDs your provider installs (e.g. `GitRepository` for a Flux provider, `ClusterPolicy` for a Kyverno provider).
+2. If any are still there, set `Status.Phase = Terminating` on the `ServiceProviderAPI`, add a condition that names the kinds blocking deletion, and requeue. Skip the rest of `Delete`.
+3. If none are left, run your normal teardown.
 
 :::warning
 There is no generic way to enumerate every CRD a domain service installs, so each provider must list the kinds it knows it owns. A force-delete escape hatch is intentionally not offered today; if you need one, raise it as a discussion before implementing it ad-hoc.

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -425,16 +425,21 @@ func (r *FooServiceReconciler) Delete(ctx context.Context, obj *apiv1alpha1.FooS
 
 ### Block deletion while user resources exist
 
-A naive `Delete` implementation removes the domain CRDs from the `ControlPlane` as soon as the user requests deletion of the service via the Onboarding cluster. Services such as Flux, Crossplane, or ESO install CRDs (e.g. `GitRepository`, `Bucket`, `ExternalSecret`) into the `ControlPlane`, and end users typically create custom resources of those CRDs. Removing the CRDs while user instances still exist may orphan those resources in the cluster and leave external systems (object storage, git repositories, secrets in vaults) outside platform control.
+End users interact with two clusters in this context:
 
-Quality criterion [Deletion behaviour](./quality-criteria#1-deletion-behaviour) requires the service provider to block deletion in this case. The expected flow inside `Delete`:
+- The **Onboarding cluster**, where they create the `ServiceProviderAPI` object that requests the service. This object is controlled by the service provider.
+- The tenant **`ControlPlane` cluster**, where they create domain custom resources (e.g. `GitRepository`, `Bucket`, `ExternalSecret`) of the CRDs your provider installs. These CRs are controlled by the domain controllers your provider manages.
 
-1. Look up the user's custom resources on `clusters.MCPCluster` for the CRDs your provider installs (e.g. `GitRepository` for a Flux provider, `ClusterPolicy` for a Kyverno provider).
-2. If any are still there, set `Status.Phase = Terminating` on the `ServiceProviderAPI`, add a condition that names the kinds blocking deletion, and requeue. Skip the rest of `Delete`.
+A naive `Delete` implementation removes those domain CRDs from the `ControlPlane` cluster as soon as the user deletes the `ServiceProviderAPI` object on the Onboarding cluster. If the domain controller does not protect its CRs with finalizers removing the CRDs while user instances still exist may orphan those resources and leave external systems (object storage, git repositories, secrets in vaults) outside platform control.
+
+A service provider can improve the user experience and prevent silent data loss by blocking its own deletion until the user has cleaned up the domain CRs first. Quality criterion [Deletion behaviour](./quality-criteria#1-deletion-behaviour) asks providers to do this whenever the underlying domain controller lacks its own deletion safeguards. The expected flow inside `Delete`:
+
+1. Look up the user's domain custom resources on `clusters.MCPCluster` for the CRDs your provider installs (e.g. `GitRepository` for a Flux provider, `ClusterPolicy` for a Kyverno provider).
+2. If any are still there, set `Status.Phase = Terminating` on the `ServiceProviderAPI` object, add a condition that names the kinds blocking deletion, and requeue. Skip the rest of `Delete`.
 3. If none are left, run your normal teardown.
 
 :::warning
-There is no generic way to enumerate every CRD a domain service installs, so each provider must list the kinds it knows it owns. A force-delete escape hatch is intentionally not offered today; if you need one, raise it as a discussion before implementing it ad-hoc.
+There is no generic way to enumerate every CRD a domain service installs, so each provider must list the kinds it knows it owns. A force-delete escape hatch is intentionally not offered today; if you need one, raise it as a [discussion](https://github.com/orgs/openmcp-project/discussions) before implementing it ad-hoc.
 :::
 
 :::info

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -423,6 +423,25 @@ func (r *FooServiceReconciler) Delete(ctx context.Context, obj *apiv1alpha1.FooS
 }
 ```
 
+### Block deletion while user resources exist
+
+A naive `Delete` implementation removes the domain CRDs from the `ControlPlane` as soon as the user deletes the `ServiceProviderAPI`. Domain services such as Flux, Crossplane, or ESO install CRDs (e.g. `GitRepository`, `Bucket`, `ExternalSecret`) into the `ControlPlane`, and end users typically create custom resources of those CRDs. Removing the CRDs while user instances still exist orphans those resources in the cluster and can leave external systems (object storage, git repositories, secrets in vaults) escaping platform control.
+
+Quality criterion [Deletion behaviour](./quality-criteria#1-deletion-behaviour) requires the service provider to block deletion in this case. The expected flow inside `Delete`:
+
+1. Before removing any managed resource, list the domain CRs on `clusters.MCPCluster` for each kind the provider installs.
+2. If any instance exists, do **not** delete the managed resources. Set `Status.Phase = Terminating` and surface a `DeletionBlocked` condition (`type: DeletionBlocked`, `status: True`, `reason: UserResourcesPresent`, `message:` naming the offending kinds and counts) so the end user can see what to clean up.
+3. Return `ctrl.Result{RequeueAfter: ...}` so the controller re-checks once the user has cleaned up.
+4. Only when no user CRs remain, proceed with the existing teardown (delete CRDs, namespaces, workloads, etc.).
+
+:::warning
+There is no generic way to enumerate every CRD a domain service installs, so each provider must list the kinds it knows it owns. A force-delete escape hatch is intentionally not offered today; if you need one, raise it as a discussion before implementing it ad-hoc.
+:::
+
+:::info
+The [service-provider-template](https://github.com/openmcp-project/service-provider-template) does not yet provide a reference implementation for this check. Progress is tracked in [openmcp-project/service-provider-template#88](https://github.com/openmcp-project/service-provider-template/issues/88).
+:::
+
 ## Restrict Cluster Access
 
 The template code runs the provider with full admin permissions. Before releasing you provider, restrict its required permissions with the [ClusterAccessReconciler](https://github.com/openmcp-project/openmcp-operator/blob/main/lib/clusteraccess/clusteraccess.go#L103). There are multiple occurrences in the `main.go` service provider setup.

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -425,7 +425,7 @@ func (r *FooServiceReconciler) Delete(ctx context.Context, obj *apiv1alpha1.FooS
 
 ### Block deletion while user resources exist
 
-A naive `Delete` implementation removes the domain CRDs from the `ControlPlane` as soon as the user requests deletion of the service via the Onboarding cluster. Services such as Flux, Crossplane, or ESO install CRDs (e.g. `GitRepository`, `Bucket`, `ExternalSecret`) into the `ControlPlane`, and end users typically create custom resources of those CRDs. Removing the CRDs while user instances still exist orphans those resources in the cluster and can leave external systems (object storage, git repositories, secrets in vaults) escaping platform control.
+A naive `Delete` implementation removes the domain CRDs from the `ControlPlane` as soon as the user requests deletion of the service via the Onboarding cluster. Services such as Flux, Crossplane, or ESO install CRDs (e.g. `GitRepository`, `Bucket`, `ExternalSecret`) into the `ControlPlane`, and end users typically create custom resources of those CRDs. Removing the CRDs while user instances still exist may orphan those resources in the cluster and leave external systems (object storage, git repositories, secrets in vaults) outside platform control.
 
 Quality criterion [Deletion behaviour](./quality-criteria#1-deletion-behaviour) requires the service provider to block deletion in this case. The expected flow inside `Delete`:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a "Block deletion while user resources exist" subsection to the Service Provider developer guide. It tells developers how to satisfy [quality criterion #1 — Deletion behaviour](https://open-control-plane.io/developers/serviceprovider/quality-criteria#1-deletion-behaviour) inside their `Delete` method, calls out the known limitations (no generic CRD enumeration, no force-delete escape hatch), and points at the follow-up issue tracking the change in the service-provider-template.

**Which issue(s) this PR fixes**:
Fixes #83

**Special notes for your reviewer**:
NONE

**Release note**:
```doc developer
Document the expected deletion flow for Service Providers when user-created custom resources of the domain CRDs still exist on the ControlPlane.
```