### PR TITLE
feat: add kro service provider documentation

### DIFF
--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -50,11 +50,11 @@ Special Interest Group focused on making it easy to build, share, and adopt exte
   <div className="sig-details" style={{margin: '16px 0 20px 0'}}>
     <div><strong>Leads:</strong> Maximilian Techritz, Christopher Junk (SAP)</div>
     <div><strong>Meetings:</strong> Bi-weekly, Wednesday 3PM CET</div>
-    <div><strong>Mailing List:</strong> opencontrolplane-extensibility@lists.neonephos.org</div>
+    <div><strong>Mailing List:</strong> openMCP-extensibility@lists.neonephos.org</div>
   </div>
 
   <div style={{display: 'flex', gap: '12px', flexWrap: 'wrap', justifyContent: 'center', marginTop: '0'}}>
-    <a href="https://lists.neonephos.org/g/opencontrolplane-extensibility/" className="subscribe-button">
+    <a href="https://lists.neonephos.org/g/openMCP-extensibility/" className="subscribe-button">
       Subscribe to Mailing List
     </a>
   </div>
@@ -80,6 +80,7 @@ Special Interest Group focused on making it easy to build, share, and adopt exte
 - [Landscaper service provider](https://github.com/openmcp-project/service-provider-landscaper)
 - [Velero service provider](https://github.com/openmcp-project/service-provider-velero)
 - [OCM service provider](https://github.com/open-component-model/service-provider-ocm)
+- [Kro service provider](https://github.com/openmcp-project/service-provider-kro)
 - [Service provider template](https://github.com/openmcp-project/repository-template)
 
 **Cluster Providers:**

--- a/docs/community/00-overview.md
+++ b/docs/community/00-overview.md
@@ -50,11 +50,11 @@ Special Interest Group focused on making it easy to build, share, and adopt exte
   <div className="sig-details" style={{margin: '16px 0 20px 0'}}>
     <div><strong>Leads:</strong> Maximilian Techritz, Christopher Junk (SAP)</div>
     <div><strong>Meetings:</strong> Bi-weekly, Wednesday 3PM CET</div>
-    <div><strong>Mailing List:</strong> openMCP-extensibility@lists.neonephos.org</div>
+    <div><strong>Mailing List:</strong> opencontrolplane-extensibility@lists.neonephos.org</div>
   </div>
 
   <div style={{display: 'flex', gap: '12px', flexWrap: 'wrap', justifyContent: 'center', marginTop: '0'}}>
-    <a href="https://lists.neonephos.org/g/openMCP-extensibility/" className="subscribe-button">
+    <a href="https://lists.neonephos.org/g/opencontrolplane-extensibility/" className="subscribe-button">
       Subscribe to Mailing List
     </a>
   </div>

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -41,4 +41,4 @@ spec:
 
 The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux HelmReleases. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform operator.
 
-The name of the `Kro` resource **must** match the name of your ManagedControlPlane. This guarantees a single kro installation per control plane.
+The name of the `Kro` resource **must** match the name of your `ControlPlane`. This guarantees a single kro installation per control plane.

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -41,4 +41,4 @@ spec:
 
 The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux HelmReleases. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform owner.
 
-The name of the `Kro` resource **must** match the name of your `ControlPlane`. This guarantees a single kro installation per control plane.
+The name of the `Kro` resource **must** match the name of your `ControlPlane`. This guarantees a single kro installation per `ControlPlane`.

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -39,6 +39,6 @@ spec:
   version: 0.9.2
 ```
 
-The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux HelmReleases. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform operator.
+The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux HelmReleases. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform owner.
 
 The name of the `Kro` resource **must** match the name of your `ControlPlane`. This guarantees a single kro installation per control plane.

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -22,6 +22,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-kro/main/api/crds/manifests/kro.services.openmcp.cloud_kroes.yaml"
   name="kro"
   description="kro service provider resource"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-kro/main/test/e2e/onboarding/kro.yaml"
 />
 
 ## Usage
@@ -38,4 +39,6 @@ spec:
   version: 0.9.2
 ```
 
-The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux HelmReleases.
+The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux HelmReleases. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform operator.
+
+The name of the `Kro` resource **must** match the name of your ManagedControlPlane. This guarantees a single kro installation per control plane.

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -39,6 +39,6 @@ spec:
   version: 0.9.2
 ```
 
-The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux HelmReleases. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform owner.
+The kro service provider installs and manages [kro](https://kro.run) on workload clusters via Flux `HelmReleases`. The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by the platform owner.
 
 The name of the `Kro` resource **must** match the name of your `ControlPlane`. This guarantees a single kro installation per `ControlPlane`.

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -159,7 +159,7 @@ The chart source, image pull secret, and Helm values are configured cluster-wide
 
 Congratulations! You have a working ControlPlane with managed services. Here's what you can explore next:
 
-- **[What is a Managed Control Plane?](../concepts/managed-control-plane.md)** — Deeper understanding of ControlPlanes
+- **[What is a ControlPlane?](../concepts/controlplane.md)** — Deeper understanding of ControlPlanes
 - **[Service Providers](../concepts/service-provider.md)** — How managed services work
 - **[Crossplane Service Provider](https://github.com/openmcp-project/service-provider-crossplane)** — Manage cloud infrastructure
 - **[Landscaper Service Provider](https://github.com/openmcp-project/service-provider-landscaper)** — Orchestrate complex workloads

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -148,7 +148,7 @@ NAME                              READY   STATUS    RESTARTS   AGE
 kro-7d9c6f8b54-abcde              1/1     Running   0          45s
 ```
 
-The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by your platform operator. See the [service-provider-kro README](https://github.com/openmcp-project/service-provider-kro#providerconfig) for the full set of tunables.
+The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by your platform owner. See the [service-provider-kro README](https://github.com/openmcp-project/service-provider-kro#providerconfig) for the full set of tunables.
 
 </TabItem>
 </Tabs>

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -116,6 +116,41 @@ Events:
 The base OCM installation comes with a bare minimum set of RBAC settings. To extend this, follow the [custom RBAC for OCM](https://github.com/open-component-model/open-component-model/blob/main/kubernetes/controller/docs/getting-started/custom-rbac.md) guide. Since you are an admin on the ControlPlane, extending the service account's RBAC should work.
 
 </TabItem>
+<TabItem value="kro" label="Kro">
+
+[Kro](https://kro.run) (Kube Resource Orchestrator) lets you create custom Kubernetes APIs by composing existing resources into higher-level abstractions. The service provider installs the Kro controller into the `kro-system` namespace on your ControlPlane via a Flux `HelmRelease`.
+
+To install the Kro operator for your ControlPlane, create a `Kro` resource in the same namespace and with the same name as your ControlPlane object:
+
+```yaml
+apiVersion: kro.services.openmcp.cloud/v1alpha1
+kind: Kro
+metadata:
+  name: my-controlplane
+  namespace: project-platform-team--ws-dev
+spec:
+  version: 0.9.1
+```
+
+```bash
+kubectl apply -f kro.yaml
+```
+
+Once this object reconciles, you can verify the Kro controller is running on the ControlPlane:
+
+```bash
+# Make sure you are using the kubeconfig for the ControlPlane
+kubectl get pods -n kro-system
+```
+
+```
+NAME                              READY   STATUS    RESTARTS   AGE
+kro-7d9c6f8b54-abcde              1/1     Running   0          45s
+```
+
+The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by your platform operator. See the [service-provider-kro README](https://github.com/openmcp-project/service-provider-kro#providerconfig) for the full set of tunables.
+
+</TabItem>
 </Tabs>
 
 ---
@@ -124,8 +159,9 @@ The base OCM installation comes with a bare minimum set of RBAC settings. To ext
 
 Congratulations! You have a working ControlPlane with managed services. Here's what you can explore next:
 
-- **[What is a ControlPlane?](../concepts/controlplane.md)** — Deeper understanding of ControlPlanes
+- **[What is a Managed Control Plane?](../concepts/managed-control-plane.md)** — Deeper understanding of ControlPlanes
 - **[Service Providers](../concepts/service-provider.md)** — How managed services work
 - **[Crossplane Service Provider](https://github.com/openmcp-project/service-provider-crossplane)** — Manage cloud infrastructure
 - **[Landscaper Service Provider](https://github.com/openmcp-project/service-provider-landscaper)** — Orchestrate complex workloads
 - **[OCM Service Provider](https://github.com/open-component-model/service-provider-ocm)** — Deliver and deploy software with the Open Component Model
+- **[Kro Service Provider](https://github.com/openmcp-project/service-provider-kro)** — Compose custom Kubernetes APIs with Kro

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -129,7 +129,7 @@ metadata:
   name: my-controlplane
   namespace: project-platform-team--ws-dev
 spec:
-  version: 0.9.1
+  version: 0.9.2
 ```
 
 ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds kro service provider documentation: community overview entry, getting-started configure tab, and enriches the existing reference CRD page with an `exampleUrl` and a note that the `Kro` resource name must match the ControlPlane name.

Resolves the merge conflict from #84 — `reference/services/kro.md` and `reference/00-overview.md` were independently added on `main`. The `03-examples.mdx` from #84 is dropped since `06-examples.mdx` already on `main` covers it (including the kro card).

**Which issue(s) this PR fixes**:
Follow-up of #84

**Special notes for your reviewer**:

This is a conflict-resolved re-submission of #84 by @Skarlso. All content is theirs; changes are limited to rebasing on top of what `main` already had.

**Release note**:
```doc user
Add kro service provider end user documentation.
```