### PR TITLE
docs(quickstart): add Linux inotify prerequisite note

### DIFF
--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -40,6 +40,19 @@ The separation ensures end users never touch infrastructure. They interact only 
 - [`flux`](https://fluxcd.io/flux/installation/#install-the-flux-cli) CLI installed
 - ~10 minutes
 
+:::note Linux: inotify limits
+The default Linux inotify limit (`fs.inotify.max_user_instances=128`) is too low when running multiple Kind clusters. If it is exhausted, `containerd` inside the ControlPlane cluster fails to initialize, which significantly delays bootstrap and can cause the `AccessRequest` controller to build up a long exponential backoff before the cluster becomes reachable.
+
+Raise the limit before you start:
+
+```shell
+sudo sysctl -w fs.inotify.max_user_instances=512
+sudo sysctl -w fs.inotify.max_user_watches=524288
+```
+
+To persist across reboots, add both lines to `/etc/sysctl.d/99-kind.conf`.
+:::
+
 ## Install ocpctl
 
 ```shell


### PR DESCRIPTION
## Summary

- Adds a note in the Prerequisites section of the Quickstart guide warning Linux users to raise `fs.inotify.max_user_instances` before running the tutorial.
- Provides the two `sysctl` commands to apply the fix immediately, plus the persistence step (`/etc/sysctl.d/99-kind.conf`).

## Background

The default Linux inotify limit (`max_user_instances=128`) is exhausted when running multiple Kind clusters simultaneously. When it is hit, `containerd` inside the ControlPlane Kind cluster fails to initialize, which delays the API server bootstrap significantly. This in turn triggers the exponential backoff bug described in [cluster-provider-kind#163](https://github.com/openmcp-project/cluster-provider-kind/issues/163): the `AccessRequest` controller builds up a large backoff interval before the API server becomes reachable, leaving the `AccessRequest` stuck in `Pending` for several minutes after the cluster is already healthy.

## Test plan

- [ ] Verified failure reproduces at `max_user_instances=128`: `AccessRequest` stays `Pending`, `cluster` controller logs `could not find a log line matching "Reached target Multi-User System"`, backoff grows to 328s → 600s cap
- [ ] Verified clean run at `max_user_instances=512`: full quickstart completes in under 7 minutes, `AccessRequest` granted on first attempt with zero errors