### PR TITLE
docs: switch to orchestrator logo

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -100,12 +100,12 @@ const config: Config = {
 
   themeConfig: {
     // Replace with your project's social card
-    image: 'img/co_axolotl.png',
+    image: 'img/opencontrolplane-icon-color.svg',
     navbar: {
       title: 'OpenControlPlane',
       logo: {
         alt: 'OpenControlPlane Logo',
-        src: 'img/co_axolotl_mirrored.png',
+        src: 'img/opencontrolplane-icon-color.svg',
       },
       items: [
         {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -269,7 +269,7 @@ export default function Home() {
               <div className="image-bg"></div>
               <img
                 className="image-src"
-                src={require("/img/co_axolotl.png").default}
+                src={require("/img/opencontrolplane-icon-color.svg").default}
                 alt="Crossplane Axolotl"
                 style={{ position: "absolute", left: 0, top: 0, width: "100%", height: "100%", objectFit: "contain", zIndex: 1 }}
               />

--- a/static/img/opencontrolplane-icon-black.svg
+++ b/static/img/opencontrolplane-icon-black.svg
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="a"
+   data-name="Layer 1"
+   width="850.39"
+   height="850.39"
+   viewBox="0 0 850.39 850.39"
+   version="1.1"
+   sodipodi:docname="open-managed-control-planes-icon-white.svg"
+   inkscape:export-filename="open-managed-control-planes-icon-white.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview44"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.030574207"
+     inkscape:cx="408.84135"
+     inkscape:cy="408.84135"
+     inkscape:current-layer="a" />
+  <defs
+     id="defs23">
+    <linearGradient
+       id="c"
+       x1="377.46"
+       y1="441.85"
+       x2="334.81"
+       y2="515.73"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop1" />
+      <stop
+         offset="0"
+         stop-color="#000"
+         id="stop2" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         id="stop3" />
+    </linearGradient>
+    <linearGradient
+       id="d"
+       x1="235.13"
+       y1="593.3"
+       x2="161.92"
+       y2="466.5"
+       gradientTransform="translate(0 847.89) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#000"
+         id="stop4" />
+      <stop
+         offset=".13"
+         stop-color="#020305"
+         id="stop5" />
+      <stop
+         offset=".29"
+         stop-color="#0a0f14"
+         id="stop6" />
+      <stop
+         offset=".47"
+         stop-color="#16212d"
+         id="stop7" />
+      <stop
+         offset=".66"
+         stop-color="#283b4f"
+         id="stop8" />
+      <stop
+         offset=".85"
+         stop-color="#3e5b7b"
+         id="stop9" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         id="stop10" />
+    </linearGradient>
+    <linearGradient
+       id="e"
+       x1="-937.98"
+       y1="590.96"
+       x2="-881.29"
+       y2="492.78"
+       gradientTransform="translate(-244.8 847.89) rotate(-180)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset=".55"
+         stop-color="#000"
+         id="stop11" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         id="stop12" />
+    </linearGradient>
+    <linearGradient
+       id="f"
+       x1="-755.01"
+       y1="427.21"
+       x2="-716.02"
+       y2="359.68"
+       gradientTransform="translate(-244.8 847.89) rotate(-180)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#000"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         id="stop14" />
+    </linearGradient>
+    <linearGradient
+       id="h"
+       x1="-1249.44"
+       y1="160.65"
+       x2="-1228.51"
+       y2="148.56"
+       gradientTransform="translate(268.07 1873.2) rotate(90) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#000"
+         id="stop15" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         stop-opacity=".8"
+         id="stop16" />
+    </linearGradient>
+    <linearGradient
+       id="i"
+       x1="-1414.87"
+       y1="160.65"
+       x2="-1393.94"
+       y2="148.56"
+       gradientTransform="translate(268.07 1873.2) rotate(90) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#000"
+         id="stop17" />
+      <stop
+         offset=".63"
+         stop-color="#354f6a"
+         stop-opacity=".87"
+         id="stop18" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         stop-opacity=".8"
+         id="stop19" />
+    </linearGradient>
+    <linearGradient
+       id="j"
+       x1="-1203.35"
+       y1="160.65"
+       x2="-1182.42"
+       y2="148.56"
+       gradientTransform="translate(268.07 1873.2) rotate(90) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#000"
+         id="stop20" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         id="stop21" />
+    </linearGradient>
+    <linearGradient
+       id="k"
+       x1="-1155.61"
+       y1="160.66"
+       x2="-1134.68"
+       y2="148.56"
+       gradientTransform="translate(268.07 1873.2) rotate(90) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#000"
+         id="stop22" />
+      <stop
+         offset="1"
+         stop-color="#5279a3"
+         id="stop23" />
+    </linearGradient>
+  </defs>
+  <g
+     id="b"
+     data-name="Layer 5">
+    <path
+       d="M161.02,252.42c3.13-29.19,29.33-51.15,65.1-47.3,35.77,3.84,51.75,30.27,48.61,59.47"
+       fill="none"
+       stroke="#221f20"
+       stroke-miterlimit="10"
+       stroke-width="6.5"
+       id="path23" />
+    <path
+       d="M683.99,253.34c-3.13-29.19-29.33-51.15-65.1-47.3-35.77,3.84-51.75,30.27-48.61,59.47"
+       fill="none"
+       stroke="#221f20"
+       stroke-miterlimit="10"
+       stroke-width="6.5"
+       id="path24" />
+    <path
+       d="M422.59,572.85l-22.32-102.51c-.3-1.37-1.48-2.36-2.89-2.4-11.84-.35-55.38-2.61-59.44-6.43l-61.71-58.06c-5.97-5.62-9.06-13.62-8.41-21.78,2.39-30,8.33-97.52,9.9-115.91.14-1.66-1.07-3.12-2.73-3.29h0l-114.36-11.66c-1.69-.17-3.19,1.07-3.35,2.76l-15.58,169.64c-.5,7.47,2.51,14.74,8.14,19.64l136.02,130.96c5.16,4.49,8.13,10.99,8.19,17.83l1.12,200.86c0,1.68,1.38,3.04,3.06,3.04l122.76-.47c1.69,0,3.05-1.38,3.04-3.07l-1.38-218.51c0-.21-.02-.42-.07-.63h.02Z"
+       id="path25" />
+    <path
+       d="M278.73,294.99l-146.63-13.95c-1.7-.16-3.21,1.09-3.36,2.79l-8.88,101.44c-.11,1.3,1.16,2.24,2.41,1.85l154.2-48.73c.82-.26,1.4-1,1.45-1.86l2.48-39.58c.06-1-.68-1.87-1.68-1.96h0Z"
+       fill="#fff"
+       id="path26" />
+    <path
+       d="M422.12,572.85l22.32-102.51c.3-1.37,1.48-2.36,2.89-2.4,11.84-.35,55.38-2.61,59.44-6.43l61.71-58.06c5.97-5.62,9.06-13.62,8.41-21.78-2.39-30-8.33-97.52-9.9-115.91-.14-1.66,1.07-3.12,2.73-3.29h0l114.36-11.66c1.69-.17,3.19,1.07,3.35,2.76l15.58,169.64c.5,7.47-2.51,14.74-8.14,19.64l-136.02,130.96c-5.16,4.49-8.13,10.99-8.19,17.83l-1.12,200.86c0,1.68-1.38,3.04-3.06,3.04l-122.76-.47c-1.69,0-3.05-1.38-3.04-3.07l1.38-218.51c0-.21.02-.42.07-.63h-.02Z"
+       id="path27" />
+    <path
+       d="M422.97,470.33l-95.29,40.72c-.79.34-1.67-.24-1.67-1.1v-86.45c0-.88.92-1.46,1.72-1.07l95.29,45.73c.92.45.89,1.76-.05,2.17Z"
+       fill="#fff"
+       isolation="isolate"
+       id="path28" />
+    <path
+       d="M422.97,470.34l-95.29,40.72c-.79.34-1.67-.24-1.67-1.1v-86.45c0-.88.92-1.46,1.72-1.07l95.29,45.73c.92.45.89,1.76-.05,2.17Z"
+       fill="url(#c)"
+       isolation="isolate"
+       opacity=".42"
+       id="path29" />
+    <path
+       d="M333.25,58.04c12.3-12.92,20.65-21.69,20.65-21.69,0,0-89.29,124.97-100.53,140.7-1.35,1.63-2.65,3.21-2.65,3.21-6.49,7.85-15.96,10.72-21.15,6.43-5.2-4.29-4.15-14.14,2.33-21.98,0,0,.66-.79,1.52-1.83,3.37-3.53,66.29-69.63,99.84-104.84h-.01Z"
+       fill="#221f20"
+       stroke="#221f20"
+       stroke-miterlimit="10"
+       id="path30" />
+    <path
+       d="M408.84,444.8s-60.8-17.85-61.15-58.84c-.07-7.92-23.67-12.82-23.67-12.82,0,0,1.29-45.95,4.69-59.2,6.14-23.97,26.14-64.07,83.07-64.07,52.77,0,70.34,37.29,73.81,59.42,4.66,29.7,5.78,78.98-11.62,119.69"
+       fill="none"
+       stroke="#221f20"
+       stroke-linecap="round"
+       stroke-miterlimit="10"
+       stroke-width="6.5"
+       id="path31" />
+    <path
+       d="M278.68,294.94l-147.81-14.06c-1.04-.1-1.96.67-2.05,1.7l-8.98,102.58c-.12,1.33,1.16,2.36,2.44,1.95l154.3-48.82c.74-.23,1.26-.9,1.31-1.67l2.49-39.7c.06-1.01-.69-1.89-1.7-1.99h0Z"
+       fill="url(#d)"
+       isolation="isolate"
+       opacity=".27"
+       id="path32" />
+    <path
+       d="M565.97,294.99l146.63-13.95c1.7-.16,3.21,1.09,3.36,2.79l8.88,101.44c.11,1.3-1.16,2.24-2.41,1.85l-154.2-48.73c-.82-.26-1.4-1-1.45-1.86l-2.48-39.58c-.06-1,.68-1.87,1.68-1.96h-.01Z"
+       fill="#fff"
+       id="path33" />
+    <path
+       d="M422.39,470.33l95.29,40.72c.79.34,1.67-.24,1.67-1.1v-86.45c0-.88-.92-1.46-1.72-1.07l-95.29,45.73c-.92.45-.89,1.76.05,2.17Z"
+       fill="#fff"
+       id="path34" />
+    <path
+       d="M566.03,294.94l147.81-14.06c1.04-.1,1.96.67,2.05,1.7l8.98,102.58c.12,1.33-1.16,2.36-2.44,1.95l-154.3-48.82c-.74-.23-1.26-.9-1.31-1.67l-2.49-39.7c-.06-1.01.69-1.89,1.7-1.99h0Z"
+       fill="url(#e)"
+       isolation="isolate"
+       opacity=".27"
+       id="path35" />
+    <path
+       d="M422.11,470.14l95.58,40.9c.79.34,1.66-.24,1.66-1.09v-86.46c0-.75-1.04-1.39-1.72-1.07l-95.55,45.86c-.8.37-.78,1.51.02,1.86h.01Z"
+       fill="url(#f)"
+       isolation="isolate"
+       opacity=".42"
+       id="path36" />
+  </g>
+  <g
+     id="g"
+     data-name="Layer 7">
+    <circle
+       cx="142.04"
+       cy="359.79"
+       r="7.87"
+       id="circle36" />
+    <circle
+       cx="700.22"
+       cy="359.79"
+       r="7.87"
+       id="circle37" />
+    <circle
+       cx="422.68"
+       cy="634.22"
+       r="12.08"
+       fill="#fff"
+       id="circle38" />
+    <circle
+       cx="422.68"
+       cy="634.22"
+       r="12.08"
+       fill="url(#h)"
+       opacity=".38"
+       id="circle39" />
+    <circle
+       cx="422.68"
+       cy="468.79"
+       r="12.08"
+       fill="#fff"
+       id="circle40" />
+    <circle
+       cx="422.68"
+       cy="468.79"
+       r="12.08"
+       fill="url(#i)"
+       opacity=".56"
+       id="circle41" />
+    <circle
+       cx="422.68"
+       cy="680.31"
+       r="12.08"
+       fill="#fff"
+       id="circle42" />
+    <circle
+       cx="422.68"
+       cy="680.31"
+       r="12.08"
+       fill="url(#j)"
+       opacity=".38"
+       id="circle43" />
+    <path
+       d="M410.6,728.06c0-6.68,5.41-12.08,12.08-12.08s12.08,5.41,12.08,12.08-5.41,12.08-12.08,12.08-12.08-5.41-12.08-12.08Z"
+       fill="#fff"
+       id="path43" />
+    <path
+       d="M410.6,728.06c0-6.68,5.41-12.08,12.08-12.08s12.08,5.41,12.08,12.08-5.41,12.08-12.08,12.08-12.08-5.41-12.08-12.08Z"
+       fill="url(#k)"
+       opacity=".38"
+       id="path44" />
+  </g>
+</svg>

--- a/static/img/opencontrolplane-icon-color.svg
+++ b/static/img/opencontrolplane-icon-color.svg
@@ -1,0 +1,749 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 701.67308 815.42455"
+   version="1.1"
+   id="svg64"
+   sodipodi:docname="openmcp_icon_color.svg"
+   width="701.6731"
+   height="815.42456"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview64"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.43"
+     inkscape:cx="366.27907"
+     inkscape:cy="410.46512"
+     inkscape:current-layer="svg64" />
+  <defs
+     id="defs44">
+    <style
+       id="style1">
+      .cls-1 {
+        filter: url(#drop-shadow-30);
+      }
+
+      .cls-1, .cls-2, .cls-3, .cls-4, .cls-5, .cls-6, .cls-7, .cls-8 {
+        fill: #fff;
+      }
+
+      .cls-2 {
+        filter: url(#drop-shadow-31);
+      }
+
+      .cls-3 {
+        filter: url(#drop-shadow-12);
+      }
+
+      .cls-4 {
+        filter: url(#drop-shadow-11);
+      }
+
+      .cls-5 {
+        filter: url(#drop-shadow-25);
+      }
+
+      .cls-6 {
+        filter: url(#drop-shadow-24);
+      }
+
+      .cls-7 {
+        filter: url(#drop-shadow-23);
+      }
+
+      .cls-9, .cls-10, .cls-11 {
+        stroke: #221f20;
+        stroke-miterlimit: 10;
+      }
+
+      .cls-9, .cls-11 {
+        fill: none;
+        stroke-width: 5.5px;
+      }
+
+      .cls-10 {
+        fill: #221f20;
+      }
+
+      .cls-12 {
+        fill: url(#linear-gradient-7);
+      }
+
+      .cls-13 {
+        fill: url(#linear-gradient-5);
+      }
+
+      .cls-14 {
+        fill: url(#linear-gradient-6);
+      }
+
+      .cls-15 {
+        fill: url(#linear-gradient-3);
+      }
+
+      .cls-16 {
+        fill: url(#linear-gradient);
+      }
+
+      .cls-17 {
+        fill: url(#linear-gradient-2);
+      }
+
+      .cls-17, .cls-18 {
+        opacity: .27;
+      }
+
+      .cls-18 {
+        fill: url(#linear-gradient-4);
+      }
+
+      .cls-19 {
+        fill: url(#linear-gradient-8);
+      }
+
+      .cls-19, .cls-20 {
+        opacity: .42;
+      }
+
+      .cls-20 {
+        fill: url(#linear-gradient-9);
+      }
+
+      .cls-21 {
+        fill: #5279a3;
+      }
+
+      .cls-22 {
+        fill: url(#linear-gradient-10);
+      }
+
+      .cls-11 {
+        stroke-linecap: round;
+      }
+    </style>
+    <linearGradient
+       id="linear-gradient"
+       x1="-5370.75"
+       y1="281.54999"
+       x2="-4905.1699"
+       y2="747.14001"
+       gradientTransform="translate(5417.06)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#53b7f9"
+         id="stop1" />
+      <stop
+         offset=".14"
+         stop-color="#50b2f8"
+         id="stop2" />
+      <stop
+         offset=".31"
+         stop-color="#49a3f5"
+         id="stop3" />
+      <stop
+         offset=".49"
+         stop-color="#3e8bf2"
+         id="stop4" />
+      <stop
+         offset=".49"
+         stop-color="#3e8bf2"
+         id="stop5" />
+      <stop
+         offset=".6"
+         stop-color="#3a82f0"
+         id="stop6" />
+      <stop
+         offset=".76"
+         stop-color="#326cec"
+         id="stop7" />
+      <stop
+         offset=".96"
+         stop-color="#2348e5"
+         id="stop8" />
+      <stop
+         offset=".99"
+         stop-color="#2142e4"
+         id="stop9" />
+    </linearGradient>
+    <filter
+       id="drop-shadow-11"
+       x="61.799999"
+       y="137.07001"
+       width="256.07999"
+       height="189.84"
+       filterUnits="userSpaceOnUse">
+      <feOffset
+         dx="-14.17"
+         dy="17.01"
+         id="feOffset9" />
+      <feGaussianBlur
+         result="blur"
+         stdDeviation="8.5"
+         id="feGaussianBlur9" />
+      <feFlood
+         flood-color="#000"
+         flood-opacity=".5"
+         id="feFlood9" />
+      <feComposite
+         in2="blur"
+         operator="in"
+         id="feComposite9" />
+      <feComposite
+         in="SourceGraphic"
+         id="feComposite10" />
+    </filter>
+    <linearGradient
+       id="linear-gradient-2"
+       x1="348.20001"
+       y1="628.48999"
+       x2="263.22"
+       y2="775.69"
+       gradientTransform="matrix(0.88506975,0.48657121,-0.43357831,0.78867601,242.83,-485.15)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop10" />
+      <stop
+         offset=".12"
+         stop-color="#c8d4e1"
+         stop-opacity=".32"
+         id="stop11" />
+      <stop
+         offset=".25"
+         stop-color="#95adc6"
+         stop-opacity=".61"
+         id="stop12" />
+      <stop
+         offset=".37"
+         stop-color="#7090b3"
+         stop-opacity=".82"
+         id="stop13" />
+      <stop
+         offset=".46"
+         stop-color="#5a7fa7"
+         stop-opacity=".95"
+         id="stop14" />
+      <stop
+         offset=".52"
+         stop-color="#5279a3"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linear-gradient-3"
+       x1="-10423.8"
+       y1="281.54999"
+       x2="-9958.2197"
+       y2="747.14001"
+       gradientTransform="matrix(-1,0,0,1,-9617.71,0)"
+       xlink:href="#linear-gradient" />
+    <filter
+       id="drop-shadow-12"
+       x="506.28"
+       y="137.07001"
+       width="256.07999"
+       height="189.84"
+       filterUnits="userSpaceOnUse">
+      <feOffset
+         dx="-14.17"
+         dy="17.01"
+         id="feOffset15" />
+      <feGaussianBlur
+         result="blur-2"
+         stdDeviation="8.5"
+         id="feGaussianBlur15" />
+      <feFlood
+         flood-color="#000"
+         flood-opacity=".5"
+         id="feFlood15" />
+      <feComposite
+         in2="blur-2"
+         operator="in"
+         id="feComposite15" />
+      <feComposite
+         in="SourceGraphic"
+         id="feComposite16" />
+    </filter>
+    <linearGradient
+       id="linear-gradient-4"
+       x1="-4014.8999"
+       y1="3328.6201"
+       x2="-4099.8901"
+       y2="3475.8201"
+       gradientTransform="matrix(-0.88506975,0.48657121,0.43357831,0.78867601,-4443.49,-485.15)"
+       xlink:href="#linear-gradient-2" />
+    <filter
+       id="drop-shadow-23"
+       x="372.12"
+       y="637.22998"
+       width="80.160004"
+       height="80.160004"
+       filterUnits="userSpaceOnUse">
+      <feOffset
+         dx="-14.17"
+         dy="17.01"
+         id="feOffset16" />
+      <feGaussianBlur
+         result="blur-3"
+         stdDeviation="8.5"
+         id="feGaussianBlur16" />
+      <feFlood
+         flood-color="#000"
+         flood-opacity=".5"
+         id="feFlood16" />
+      <feComposite
+         in2="blur-3"
+         operator="in"
+         id="feComposite17" />
+      <feComposite
+         in="SourceGraphic"
+         id="feComposite18" />
+    </filter>
+    <linearGradient
+       id="linear-gradient-5"
+       x1="-1350.65"
+       y1="551.27002"
+       x2="-1325.75"
+       y2="565.64001"
+       gradientTransform="rotate(90,-506.87,1491.58)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop18" />
+      <stop
+         offset=".08"
+         stop-color="#e5ebf1"
+         stop-opacity=".12"
+         id="stop19" />
+      <stop
+         offset=".29"
+         stop-color="#a6bacf"
+         stop-opacity=".41"
+         id="stop20" />
+      <stop
+         offset=".47"
+         stop-color="#7896b7"
+         stop-opacity=".62"
+         id="stop21" />
+      <stop
+         offset=".63"
+         stop-color="#5c80a8"
+         stop-opacity=".75"
+         id="stop22" />
+      <stop
+         offset=".73"
+         stop-color="#5279a3"
+         stop-opacity=".8"
+         id="stop23" />
+    </linearGradient>
+    <filter
+       id="drop-shadow-24"
+       x="372.12"
+       y="691.95001"
+       width="80.160004"
+       height="80.160004"
+       filterUnits="userSpaceOnUse">
+      <feOffset
+         dx="-14.17"
+         dy="17.01"
+         id="feOffset23" />
+      <feGaussianBlur
+         result="blur-4"
+         stdDeviation="8.5"
+         id="feGaussianBlur23" />
+      <feFlood
+         flood-color="#000"
+         flood-opacity=".5"
+         id="feFlood23" />
+      <feComposite
+         in2="blur-4"
+         operator="in"
+         id="feComposite23" />
+      <feComposite
+         in="SourceGraphic"
+         id="feComposite24" />
+    </filter>
+    <linearGradient
+       id="linear-gradient-6"
+       x1="-1295.84"
+       y1="551.27002"
+       x2="-1270.9399"
+       y2="565.64001"
+       xlink:href="#linear-gradient-5" />
+    <filter
+       id="drop-shadow-25"
+       x="372.12"
+       y="748.83002"
+       width="80.160004"
+       height="80.160004"
+       filterUnits="userSpaceOnUse">
+      <feOffset
+         dx="-14.17"
+         dy="17.01"
+         id="feOffset24" />
+      <feGaussianBlur
+         result="blur-5"
+         stdDeviation="8.5"
+         id="feGaussianBlur24" />
+      <feFlood
+         flood-color="#000"
+         flood-opacity=".5"
+         id="feFlood24" />
+      <feComposite
+         in2="blur-5"
+         operator="in"
+         id="feComposite25" />
+      <feComposite
+         in="SourceGraphic"
+         id="feComposite26" />
+    </filter>
+    <linearGradient
+       id="linear-gradient-7"
+       x1="-1239.0601"
+       y1="551.27002"
+       x2="-1214.16"
+       y2="565.64001"
+       xlink:href="#linear-gradient-5" />
+    <filter
+       id="drop-shadow-30"
+       x="268.44"
+       y="412.35001"
+       width="170.64"
+       height="159.84"
+       filterUnits="userSpaceOnUse">
+      <feOffset
+         dx="-14.17"
+         dy="17.01"
+         id="feOffset26" />
+      <feGaussianBlur
+         result="blur-6"
+         stdDeviation="8.5"
+         id="feGaussianBlur26" />
+      <feFlood
+         flood-color="#000"
+         flood-opacity=".5"
+         id="feFlood26" />
+      <feComposite
+         in2="blur-6"
+         operator="in"
+         id="feComposite27" />
+      <feComposite
+         in="SourceGraphic"
+         id="feComposite28" />
+    </filter>
+    <linearGradient
+       id="linear-gradient-8"
+       x1="369.57999"
+       y1="447.59"
+       x2="324.20999"
+       y2="526.17999"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop28" />
+      <stop
+         offset="0"
+         stop-color="#fbfcfd"
+         stop-opacity=".02"
+         id="stop29" />
+      <stop
+         offset=".08"
+         stop-color="#ced9e5"
+         stop-opacity=".28"
+         id="stop30" />
+      <stop
+         offset=".17"
+         stop-color="#a8bbd0"
+         stop-opacity=".5"
+         id="stop31" />
+      <stop
+         offset=".25"
+         stop-color="#88a3c0"
+         stop-opacity=".68"
+         id="stop32" />
+      <stop
+         offset=".35"
+         stop-color="#7090b3"
+         stop-opacity=".82"
+         id="stop33" />
+      <stop
+         offset=".44"
+         stop-color="#5f83aa"
+         stop-opacity=".92"
+         id="stop34" />
+      <stop
+         offset=".55"
+         stop-color="#557ba4"
+         stop-opacity=".98"
+         id="stop35" />
+      <stop
+         offset=".7"
+         stop-color="#5279a3"
+         id="stop36" />
+    </linearGradient>
+    <filter
+       id="drop-shadow-31"
+       x="385.32001"
+       y="412.35001"
+       width="170.64"
+       height="159.84"
+       filterUnits="userSpaceOnUse">
+      <feOffset
+         dx="-14.17"
+         dy="17.01"
+         id="feOffset36" />
+      <feGaussianBlur
+         result="blur-7"
+         stdDeviation="8.5"
+         id="feGaussianBlur36" />
+      <feFlood
+         flood-color="#000"
+         flood-opacity=".5"
+         id="feFlood36" />
+      <feComposite
+         in2="blur-7"
+         operator="in"
+         id="feComposite36" />
+      <feComposite
+         in="SourceGraphic"
+         id="feComposite37" />
+    </filter>
+    <linearGradient
+       id="linear-gradient-9"
+       x1="-1034.45"
+       y1="419.03"
+       x2="-986.83002"
+       y2="501.5"
+       gradientTransform="matrix(-1,0,0,1,-501.3,0)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop37" />
+      <stop
+         offset=".02"
+         stop-color="#f5f7fa"
+         stop-opacity=".05"
+         id="stop38" />
+      <stop
+         offset=".16"
+         stop-color="#c4d1df"
+         stop-opacity=".34"
+         id="stop39" />
+      <stop
+         offset=".29"
+         stop-color="#9bb1c9"
+         stop-opacity=".58"
+         id="stop40" />
+      <stop
+         offset=".42"
+         stop-color="#7b98b8"
+         stop-opacity=".76"
+         id="stop41" />
+      <stop
+         offset=".55"
+         stop-color="#6487ac"
+         stop-opacity=".89"
+         id="stop42" />
+      <stop
+         offset=".67"
+         stop-color="#567ca5"
+         stop-opacity=".97"
+         id="stop43" />
+      <stop
+         offset=".79"
+         stop-color="#5279a3"
+         id="stop44" />
+    </linearGradient>
+    <linearGradient
+       id="linear-gradient-10"
+       x1="-1533.64"
+       y1="551.03003"
+       x2="-1507.9"
+       y2="565.88"
+       xlink:href="#linear-gradient-5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linear-gradient"
+       id="linearGradient64"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(5417.06)"
+       x1="-5370.75"
+       y1="281.54999"
+       x2="-4905.1699"
+       y2="747.14001" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linear-gradient-2"
+       id="linearGradient65"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88506975,0.48657121,-0.43357831,0.78867601,242.83,-485.15)"
+       x1="348.20001"
+       y1="628.48999"
+       x2="263.22"
+       y2="775.69" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linear-gradient-5"
+       id="linearGradient66"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,-506.87,1491.58)"
+       x1="-1350.65"
+       y1="551.27002"
+       x2="-1325.75"
+       y2="565.64001" />
+  </defs>
+  <g
+     id="Layer_5"
+     data-name="Layer 5"
+     transform="translate(-61.799999,-17.865499)">
+    <path
+       class="cls-9"
+       d="m 244.12,186.88 -57.17,-39.97 c 13.04,-18.65 34.42,-29.79 57.17,-29.79 38.27,0 69.76,31.49 69.76,69.76 0,13.84 -4.12,27.37 -11.83,38.86 z"
+       id="path44" />
+    <polygon
+       class="cls-8"
+       points="465.27,463.52 399.29,467.24 423.45,601.05 "
+       id="polygon44" />
+    <path
+       class="cls-16"
+       d="M 427.23,587.26 402.51,473.73 c -1.42,-6.51 -7.03,-11.26 -13.69,-11.57 -16.59,-0.76 -45.86,-2.64 -57.57,-5.49 -2.64,-0.64 -4.95,-2.21 -6.51,-4.44 L 242.52,334.39 c -3.16,-3.32 -3.48,-8.43 -0.76,-12.12 l 62.65,-92.94 c 3.01,-4.07 1.89,-9.85 -2.41,-12.51 L 195.18,144.05 c -3.19,-1.97 -7.03,-2.04 -10.19,-0.49 -2.15,1.06 -3.79,2.95 -4.78,5.13 L 89.92,366.21 c -1.64,3.59 -1.25,7.78 1.03,11 l 178.32,225.5 c 3.31,4.48 5.1,9.9 5.12,15.47 l 0.78,211.5 c 0.01,2 1.64,3.62 3.65,3.61 l 145.99,-0.56 c 2.01,0 3.63,-1.65 3.62,-3.66 l -1.11,-241.06 c 0,-0.25 -0.03,-0.5 -0.08,-0.75 z"
+       id="path45"
+       style="fill:url(#linearGradient64)" />
+    <path
+       class="cls-4"
+       d="M 305.16,244.72 157.27,146.38 c -1.72,-1.14 -3.96,-0.84 -5,0.67 l -50.39,99.54 c -0.8,1.16 0.07,2.78 1.59,3.14 l 176.87,34.46 c 1,0.23 2,-0.12 2.5,-0.9 l 23.06,-35.74 c 0.58,-0.9 0.25,-2.15 -0.76,-2.82 z"
+       id="path46" />
+    <path
+       class="cls-11"
+       d="m 404.17,448.97 c 0,0 -72.3,-21.23 -72.72,-69.98 -0.08,-9.41 -28.15,-15.25 -28.15,-15.25 0,0 1.53,-54.65 5.57,-70.41 7.3,-28.5 31.08,-76.19 98.79,-76.19 62.76,0 83.64,44.35 87.77,70.66 5.54,35.32 6.87,93.92 -13.82,142.34"
+       id="path47" />
+    <path
+       class="cls-17"
+       d="M 305.13,244.64 156.05,145.5 c -1.05,-0.7 -2.42,-0.51 -3.05,0.41 l -51.08,100.56 c -0.81,1.19 0,2.89 1.57,3.25 l 177.03,34.43 c 0.9,0.21 1.8,-0.11 2.25,-0.81 l 23.14,-35.85 c 0.59,-0.91 0.25,-2.18 -0.77,-2.85 z"
+       id="path48"
+       style="fill:url(#linearGradient65)" />
+    <path
+       class="cls-9"
+       d="m 608.28,186.88 57.17,-39.97 c -13.04,-18.65 -34.42,-29.79 -57.17,-29.79 -38.27,0 -69.76,31.49 -69.76,69.76 0,13.84 4.12,27.37 11.83,38.86 z"
+       id="path49" />
+    <path
+       class="cls-15"
+       d="m 425.16,587.26 24.72,-113.53 c 1.42,-6.51 7.03,-11.26 13.69,-11.57 16.59,-0.76 45.86,-2.64 57.57,-5.49 2.64,-0.64 4.95,-2.21 6.51,-4.44 l 82.22,-117.84 c 3.16,-3.32 3.48,-8.43 0.76,-12.12 l -62.65,-92.94 c -3.01,-4.07 -1.89,-9.85 2.41,-12.51 l 106.82,-72.77 c 3.19,-1.97 7.03,-2.04 10.19,-0.49 2.15,1.06 3.79,2.95 4.78,5.13 l 90.29,217.52 c 1.64,3.59 1.25,7.78 -1.03,11 l -178.32,225.5 c -3.31,4.48 -5.1,9.9 -5.12,15.47 l -0.78,211.5 c -0.01,2 -1.64,3.62 -3.65,3.61 l -145.99,-0.56 c -2.01,0 -3.63,-1.65 -3.62,-3.66 l 1.11,-241.06 c 0,-0.25 0.03,-0.5 0.08,-0.75 z"
+       id="path50"
+       style="fill:url(#linear-gradient-3)" />
+    <path
+       class="cls-3"
+       d="m 547.23,244.72 147.89,-98.34 c 1.72,-1.14 3.96,-0.84 5,0.67 l 50.39,99.54 c 0.8,1.16 -0.07,2.78 -1.59,3.14 l -176.87,34.46 c -1,0.23 -2,-0.12 -2.5,-0.9 l -23.06,-35.74 c -0.58,-0.9 -0.25,-2.15 0.76,-2.82 z"
+       id="path51" />
+    <path
+       class="cls-18"
+       d="M 547.26,244.64 696.34,145.5 c 1.05,-0.7 2.42,-0.51 3.05,0.41 l 51.08,100.56 c 0.81,1.19 0,2.89 -1.57,3.25 l -177.03,34.43 c -0.9,0.21 -1.8,-0.11 -2.25,-0.81 l -23.14,-35.85 c -0.59,-0.91 -0.25,-2.18 0.77,-2.85 z"
+       id="path52"
+       style="fill:url(#linear-gradient-4)" />
+    <path
+       class="cls-10"
+       d="m 471.21,31.51 c 19.71,-7.85 33.09,-13.18 33.09,-13.18 0,0 -158.54,90.68 -178.51,102.11 -2.27,1.09 -4.46,2.15 -4.46,2.15 -10.9,5.26 -22.57,3.67 -26.05,-3.56 -3.48,-7.22 2.53,-17.34 13.44,-22.6 0,0 1.1,-0.53 2.55,-1.23 5.4,-2.15 106.22,-42.3 159.95,-63.7 z"
+       id="path53" />
+  </g>
+  <g
+     id="Layer_7"
+     data-name="Layer 7"
+     transform="translate(-61.799999,-17.865499)">
+    <circle
+       class="cls-21"
+       cx="132.44"
+       cy="233.78"
+       r="9.3599997"
+       id="circle53" />
+    <circle
+       class="cls-21"
+       cx="716.59003"
+       cy="233.78"
+       r="9.3599997"
+       id="circle54" />
+    <circle
+       class="cls-7"
+       cx="426.26001"
+       cy="660.25"
+       r="14.37"
+       id="circle55" />
+    <circle
+       class="cls-13"
+       cx="426.26001"
+       cy="660.25"
+       r="14.37"
+       id="circle56"
+       style="fill:url(#linearGradient66)" />
+    <circle
+       class="cls-6"
+       cx="426.26001"
+       cy="715.06"
+       r="14.37"
+       id="circle57" />
+    <circle
+       class="cls-14"
+       cx="426.26001"
+       cy="715.06"
+       r="14.37"
+       id="circle58"
+       style="fill:url(#linear-gradient-6)" />
+    <path
+       class="cls-5"
+       d="m 411.88,771.84 c 0,-7.94 6.43,-14.37 14.37,-14.37 7.94,0 14.37,6.43 14.37,14.37 0,7.94 -6.43,14.37 -14.37,14.37 -7.94,0 -14.37,-6.43 -14.37,-14.37 z"
+       id="path58" />
+    <path
+       class="cls-12"
+       d="m 411.88,771.84 c 0,-7.94 6.43,-14.37 14.37,-14.37 7.94,0 14.37,6.43 14.37,14.37 0,7.94 -6.43,14.37 -14.37,14.37 -7.94,0 -14.37,-6.43 -14.37,-14.37 z"
+       id="path59"
+       style="fill:url(#linear-gradient-7)" />
+    <path
+       class="cls-1"
+       d="m 426.61,479.66 -116.38,49.73 c -0.96,0.42 -2.04,-0.29 -2.04,-1.34 V 422.47 c 0,-1.08 1.13,-1.79 2.1,-1.31 l 116.38,55.85 c 1.12,0.55 1.08,2.16 -0.06,2.65 z"
+       id="path60" />
+    <path
+       class="cls-19"
+       d="m 426.96,479.44 -116.73,49.95 c -0.96,0.42 -2.04,-0.29 -2.04,-1.34 V 422.46 c 0,-0.91 1.27,-1.7 2.1,-1.31 l 116.69,56.01 c 0.98,0.45 0.96,1.85 -0.03,2.27 z"
+       id="path61"
+       style="fill:url(#linear-gradient-8)" />
+    <path
+       class="cls-2"
+       d="m 425.9,479.66 116.38,49.73 c 0.96,0.42 2.04,-0.29 2.04,-1.34 V 422.47 c 0,-1.08 -1.13,-1.79 -2.1,-1.31 l -116.38,55.85 c -1.12,0.55 -1.08,2.16 0.06,2.65 z"
+       id="path62" />
+    <path
+       class="cls-20"
+       d="m 425.55,479.42 116.73,49.95 c 0.96,0.42 2.04,-0.29 2.04,-1.34 V 422.44 c 0,-0.91 -1.27,-1.7 -2.1,-1.31 l -116.69,56.01 c -0.98,0.45 -0.96,1.85 0.03,2.27 z"
+       id="path63"
+       style="fill:url(#linear-gradient-9)" />
+    <circle
+       class="cls-8"
+       cx="426.26001"
+       cy="477.78"
+       r="14.76"
+       id="circle63" />
+    <circle
+       class="cls-22"
+       cx="426.26001"
+       cy="477.69"
+       r="14.86"
+       id="circle64"
+       style="fill:url(#linear-gradient-10)" />
+  </g>
+</svg>

--- a/static/img/opencontrolplane-icon-white.svg
+++ b/static/img/opencontrolplane-icon-white.svg
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="a"
+   data-name="Layer 1"
+   width="850.39"
+   height="850.39"
+   viewBox="0 0 850.39 850.39"
+   version="1.1"
+   sodipodi:docname="open-managed-control-planes-icon-white.svg"
+   inkscape:export-filename="open-managed-control-planes-icon-white.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview69"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.030574207"
+     inkscape:cx="408.84135"
+     inkscape:cy="408.84135"
+     inkscape:current-layer="a" />
+  <defs
+     id="defs47">
+    <linearGradient
+       id="c"
+       x1="248.57"
+       y1="590.46"
+       x2="175.6"
+       y2="464.08"
+       gradientTransform="translate(0 847.89) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop1" />
+      <stop
+         offset=".12"
+         stop-color="#c8d4e1"
+         stop-opacity=".32"
+         id="stop2" />
+      <stop
+         offset=".25"
+         stop-color="#95adc6"
+         stop-opacity=".61"
+         id="stop3" />
+      <stop
+         offset=".37"
+         stop-color="#7090b3"
+         stop-opacity=".82"
+         id="stop4" />
+      <stop
+         offset=".46"
+         stop-color="#5a7fa7"
+         stop-opacity=".95"
+         id="stop5" />
+      <stop
+         offset=".52"
+         stop-color="#5279a3"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="d"
+       x1="389.27"
+       y1="401.59"
+       x2="352.24"
+       y2="337.44"
+       gradientTransform="translate(0 847.89) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop7" />
+      <stop
+         offset="0"
+         stop-color="#fbfcfd"
+         stop-opacity=".02"
+         id="stop8" />
+      <stop
+         offset=".08"
+         stop-color="#ced9e5"
+         stop-opacity=".28"
+         id="stop9" />
+      <stop
+         offset=".17"
+         stop-color="#a8bbd0"
+         stop-opacity=".5"
+         id="stop10" />
+      <stop
+         offset=".25"
+         stop-color="#88a3c0"
+         stop-opacity=".68"
+         id="stop11" />
+      <stop
+         offset=".35"
+         stop-color="#7090b3"
+         stop-opacity=".82"
+         id="stop12" />
+      <stop
+         offset=".44"
+         stop-color="#5f83aa"
+         stop-opacity=".92"
+         id="stop13" />
+      <stop
+         offset=".55"
+         stop-color="#557ba4"
+         stop-opacity=".98"
+         id="stop14" />
+      <stop
+         offset=".7"
+         stop-color="#5279a3"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="e"
+       x1="-2734.73"
+       y1="588.13"
+       x2="-2678.23"
+       y2="490.27"
+       gradientTransform="translate(-2029.6 847.89) rotate(-180)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop16" />
+      <stop
+         offset=".15"
+         stop-color="#c8d4e1"
+         stop-opacity=".32"
+         id="stop17" />
+      <stop
+         offset=".3"
+         stop-color="#95adc6"
+         stop-opacity=".61"
+         id="stop18" />
+      <stop
+         offset=".44"
+         stop-color="#7090b3"
+         stop-opacity=".82"
+         id="stop19" />
+      <stop
+         offset=".55"
+         stop-color="#5a7fa7"
+         stop-opacity=".95"
+         id="stop20" />
+      <stop
+         offset=".63"
+         stop-color="#5279a3"
+         id="stop21" />
+    </linearGradient>
+    <linearGradient
+       id="f"
+       x1="-2552.36"
+       y1="424.91"
+       x2="-2513.49"
+       y2="357.6"
+       gradientTransform="translate(-2029.6 847.89) rotate(-180)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop22" />
+      <stop
+         offset=".02"
+         stop-color="#f5f7fa"
+         stop-opacity=".05"
+         id="stop23" />
+      <stop
+         offset=".16"
+         stop-color="#c4d1df"
+         stop-opacity=".34"
+         id="stop24" />
+      <stop
+         offset=".29"
+         stop-color="#9bb1c9"
+         stop-opacity=".58"
+         id="stop25" />
+      <stop
+         offset=".42"
+         stop-color="#7b98b8"
+         stop-opacity=".76"
+         id="stop26" />
+      <stop
+         offset=".55"
+         stop-color="#6487ac"
+         stop-opacity=".89"
+         id="stop27" />
+      <stop
+         offset=".67"
+         stop-color="#567ca5"
+         stop-opacity=".97"
+         id="stop28" />
+      <stop
+         offset=".79"
+         stop-color="#5279a3"
+         id="stop29" />
+    </linearGradient>
+    <linearGradient
+       id="h"
+       x1="-2305.09"
+       y1="1065.87"
+       x2="-2284.23"
+       y2="1053.82"
+       gradientTransform="translate(-624.33 2765.6) rotate(90) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop30" />
+      <stop
+         offset=".08"
+         stop-color="#e5ebf1"
+         stop-opacity=".12"
+         id="stop31" />
+      <stop
+         offset=".29"
+         stop-color="#a6bacf"
+         stop-opacity=".41"
+         id="stop32" />
+      <stop
+         offset=".47"
+         stop-color="#7896b7"
+         stop-opacity=".62"
+         id="stop33" />
+      <stop
+         offset=".63"
+         stop-color="#5c80a8"
+         stop-opacity=".75"
+         id="stop34" />
+      <stop
+         offset=".73"
+         stop-color="#5279a3"
+         stop-opacity=".8"
+         id="stop35" />
+    </linearGradient>
+    <linearGradient
+       id="i"
+       x1="-2094.26"
+       y1="1065.87"
+       x2="-2073.4"
+       y2="1053.82"
+       gradientTransform="translate(-624.33 2765.6) rotate(90) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop36" />
+      <stop
+         offset=".08"
+         stop-color="#e5ebf1"
+         stop-opacity=".12"
+         id="stop37" />
+      <stop
+         offset=".29"
+         stop-color="#a6bacf"
+         stop-opacity=".41"
+         id="stop38" />
+      <stop
+         offset=".47"
+         stop-color="#7896b7"
+         stop-opacity=".62"
+         id="stop39" />
+      <stop
+         offset=".63"
+         stop-color="#5c80a8"
+         stop-opacity=".75"
+         id="stop40" />
+      <stop
+         offset=".73"
+         stop-color="#5279a3"
+         stop-opacity=".8"
+         id="stop41" />
+    </linearGradient>
+    <linearGradient
+       id="j"
+       x1="-2141.56"
+       x2="-2120.7"
+       xlink:href="#i" />
+    <linearGradient
+       id="k"
+       x1="-2046.68"
+       y1="1065.87"
+       x2="-2025.81"
+       y2="1053.82"
+       gradientTransform="translate(-624.33 2765.6) rotate(90) scale(1 -1)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop42" />
+      <stop
+         offset=".08"
+         stop-color="#e5ebf1"
+         stop-opacity=".12"
+         id="stop43" />
+      <stop
+         offset=".29"
+         stop-color="#a6bacf"
+         stop-opacity=".41"
+         id="stop44" />
+      <stop
+         offset=".47"
+         stop-color="#7896b7"
+         stop-opacity=".62"
+         id="stop45" />
+      <stop
+         offset=".63"
+         stop-color="#5c80a8"
+         stop-opacity=".75"
+         id="stop46" />
+      <stop
+         offset=".73"
+         stop-color="#5279a3"
+         stop-opacity=".8"
+         id="stop47" />
+    </linearGradient>
+  </defs>
+  <g
+     id="b"
+     data-name="Layer 5">
+    <path
+       d="M174.7,258.25c3.12-29.1,29.24-53.97,64.89-50.14,35.65,3.83,50.58,30.17,47.46,59.28"
+       fill="none"
+       stroke="#fff"
+       stroke-miterlimit="10"
+       stroke-width="6.5"
+       id="path47" />
+    <path
+       d="M695.98,256.18c-3.12-29.1-29.24-50.98-64.89-47.15-35.65,3.83-51.58,30.17-48.45,59.28"
+       fill="none"
+       stroke="#fff"
+       stroke-miterlimit="10"
+       stroke-width="6.5"
+       id="path48" />
+    <path
+       d="M435.42,574.65l-22.25-102.18c-.3-1.37-1.48-2.35-2.88-2.39-11.8-.35-55.2-2.6-59.25-6.41l-61.51-57.87c-5.95-5.6-9.03-13.58-8.38-21.71,2.38-29.91,8.3-97.2,9.87-115.53.14-1.66-1.07-3.11-2.72-3.28h0l-113.99-11.62c-1.69-.17-3.18,1.07-3.34,2.75l-15.53,169.09c-.5,7.44,2.5,14.69,8.11,19.58l135.58,130.54c5.14,4.48,8.1,10.96,8.16,17.77l1.12,200.21c0,1.68,1.38,3.03,3.05,3.03l122.36-.47c1.69,0,3.04-1.38,3.03-3.06l-1.38-217.8c0-.21-.02-.42-.07-.63h.02Z"
+       fill="#fff"
+       id="path49" />
+    <path
+       d="M292.04,297.69l-146.15-13.9c-1.7-.16-3.2,1.09-3.35,2.78l-8.85,101.11c-.11,1.3,1.16,2.24,2.4,1.85l153.7-48.57c.82-.26,1.4-1,1.45-1.86l2.47-39.45c.06-1-.68-1.87-1.68-1.96h0Z"
+       fill="#fff"
+       id="path50" />
+    <path
+       d="M434.96,574.65l22.25-102.18c.3-1.37,1.48-2.35,2.88-2.39,11.8-.35,55.2-2.6,59.25-6.41l61.51-57.87c5.95-5.6,9.03-13.58,8.38-21.71-2.38-29.91-8.3-97.2-9.87-115.53-.14-1.66,1.07-3.11,2.72-3.28h0l113.99-11.62c1.69-.17,3.18,1.07,3.34,2.75l15.53,169.09c.5,7.44-2.5,14.69-8.11,19.58l-135.58,130.54c-5.14,4.48-8.1,10.96-8.16,17.77l-1.12,200.21c0,1.68-1.38,3.03-3.05,3.03l-122.36-.47c-1.69,0-3.04-1.38-3.03-3.06l1.38-217.8c0-.21.02-.42.07-.63h-.02Z"
+       fill="#fff"
+       id="path51" />
+    <path
+       d="M435.8,472.46l-94.98,40.59c-.79.34-1.67-.24-1.67-1.1v-86.17c0-.88.92-1.46,1.72-1.07l94.98,45.58c.92.45.89,1.76-.05,2.17Z"
+       fill="#fff"
+       id="path52" />
+    <path
+       d="M346.38,61.51c12.26-12.88,20.59-21.62,20.59-21.62,0,0-89,124.56-100.2,140.25-1.35,1.63-2.64,3.2-2.64,3.2-6.47,7.82-15.91,10.69-21.08,6.41-5.18-4.28-4.14-14.09,2.32-21.91,0,0,.66-.79,1.52-1.83,3.36-3.52,66.08-69.4,99.51-104.5h0Z"
+       fill="#fff"
+       stroke="#fff"
+       stroke-miterlimit="10"
+       id="path53" />
+    <path
+       d="M421.71,447.02s-60.6-17.79-60.95-58.65c-.07-7.89-23.59-12.78-23.59-12.78,0,0,1.29-45.8,4.67-59.01,6.12-23.89,26.05-63.86,82.8-63.86,52.6,0,70.11,37.17,73.57,59.23,4.64,29.61,5.76,78.72-11.58,119.3"
+       fill="none"
+       stroke="#fff"
+       stroke-linecap="round"
+       stroke-miterlimit="10"
+       stroke-width="6.5"
+       id="path54" />
+    <path
+       d="M291.99,297.64l-147.33-14.01c-1.04-.1-1.96.67-2.05,1.7l-8.95,102.25c-.12,1.33,1.16,2.35,2.43,1.95l153.8-48.66c.74-.23,1.26-.9,1.31-1.67l2.48-39.57c.06-1.01-.69-1.89-1.7-1.99h0Z"
+       fill="url(#c)"
+       isolation="isolate"
+       opacity=".27"
+       id="path55" />
+    <path
+       d="M436.09,472.29l-95.27,40.77c-.79.34-1.66-.24-1.66-1.09v-86.18c0-.75,1.04-1.39,1.72-1.07l95.24,45.71c.8.37.78,1.51-.02,1.86h0Z"
+       fill="url(#d)"
+       isolation="isolate"
+       opacity=".42"
+       id="path56" />
+    <path
+       d="M578.33,297.69l146.15-13.9c1.7-.16,3.2,1.09,3.35,2.78l8.85,101.11c.11,1.3-1.16,2.24-2.4,1.85l-153.7-48.57c-.82-.26-1.4-1-1.45-1.86l-2.47-39.45c-.06-1,.68-1.87,1.68-1.96h0Z"
+       fill="#fff"
+       id="path57" />
+    <path
+       d="M435.22,472.46l94.98,40.59c.79.34,1.67-.24,1.67-1.1v-86.17c0-.88-.92-1.46-1.72-1.07l-94.98,45.58c-.92.45-.89,1.76.05,2.17Z"
+       fill="#fff"
+       id="path58" />
+    <path
+       d="M578.39,297.64l147.33-14.01c1.04-.1,1.96.67,2.05,1.7l8.95,102.25c.12,1.33-1.16,2.35-2.43,1.95l-153.8-48.66c-.74-.23-1.26-.9-1.31-1.67l-2.48-39.57c-.06-1.01.69-1.89,1.7-1.99h0Z"
+       fill="url(#e)"
+       isolation="isolate"
+       opacity=".27"
+       id="path59" />
+    <path
+       d="M434.95,472.27l95.27,40.77c.79.34,1.66-.24,1.66-1.09v-86.18c0-.75-1.04-1.39-1.72-1.07l-95.24,45.71c-.8.37-.78,1.51.02,1.86h0Z"
+       fill="url(#f)"
+       isolation="isolate"
+       opacity=".42"
+       id="path60" />
+  </g>
+  <g
+     id="g"
+     data-name="Layer 7">
+    <circle
+       cx="155.78"
+       cy="362.28"
+       r="7.84"
+       fill="#5279a3"
+       id="circle60" />
+    <circle
+       cx="712.15"
+       cy="362.28"
+       r="7.84"
+       fill="#5279a3"
+       id="circle61" />
+    <circle
+       cx="435.51"
+       cy="635.83"
+       r="12.04"
+       fill="#fff"
+       id="circle62" />
+    <circle
+       cx="435.51"
+       cy="635.83"
+       r="12.04"
+       fill="#fff"
+       id="circle63" />
+    <circle
+       cx="435.51"
+       cy="470.94"
+       r="12.04"
+       fill="#fff"
+       id="circle64" />
+    <circle
+       cx="435.51"
+       cy="470.94"
+       r="12.04"
+       fill="url(#h)"
+       id="circle65" />
+    <circle
+       cx="435.51"
+       cy="681.77"
+       r="12.04"
+       fill="#fff"
+       id="circle66" />
+    <circle
+       cx="435.51"
+       cy="681.77"
+       r="12.04"
+       fill="url(#i)"
+       id="circle67" />
+    <circle
+       cx="435.51"
+       cy="634.47"
+       r="12.04"
+       fill="url(#j)"
+       id="circle68" />
+    <path
+       d="M423.47,729.36c0-6.66,5.39-12.04,12.04-12.04s12.04,5.39,12.04,12.04-5.39,12.04-12.04,12.04-12.04-5.39-12.04-12.04Z"
+       fill="#fff"
+       id="path68" />
+    <path
+       d="M423.47,729.36c0-6.66,5.39-12.04,12.04-12.04s12.04,5.39,12.04,12.04-5.39,12.04-12.04,12.04-12.04-5.39-12.04-12.04Z"
+       fill="url(#k)"
+       id="path69" />
+  </g>
+</svg>


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, we are switching (back) to the Orchestrator logo for the time being because of Linux Foundation legal reasons. 

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Switching to Orchestrator logo
```