### PR TITLE
docs: update API versions, kinds, and quickstart next steps

### DIFF
--- a/docs/developers/clusters-and-namespaces.md
+++ b/docs/developers/clusters-and-namespaces.md
@@ -64,7 +64,7 @@ The Onboarding Cluster is the entry point for end users. Namespaces follow a hie
 | Namespace | Created By | Contains |
 |-----------|-----------|----------|
 | `project-<project-name>` | Creating a `Project` | Workspaces, project-scoped resources |
-| `project-<project-name>--ws-<workspace-name>` | Creating a `Workspace` | `ManagedControlPlaneV2` resources, ServiceProviderAPI instances |
+| `project-<project-name>--ws-<workspace-name>` | Creating a `Workspace` | `ControlPlane` resources, service resources |
 
 
 For example, a project named `platform-team` with a workspace `dev` results in:

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -121,7 +121,7 @@ Modify the spec to expose the configuration your provider supports.
 For example, Velero allows the user to choose a version and which plugins to install:
 
 ```yaml
-apiVersion: velero.services.openmcp.cloud/v1alpha1
+apiVersion: velero.services.open-control-plane.io/v1alpha1
 kind: Velero
 metadata:
   name: test-controlplane
@@ -204,7 +204,7 @@ It is required to add this for new service providers until dedicated Registry an
 Velero's ProviderConfig currently includes both operational settings and deployment artifacts:
 
 ```yaml
-apiVersion: velero.services.openmcp.cloud/v1alpha1
+apiVersion: velero.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: default

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -255,6 +255,45 @@ The team now has a fully functional control plane with Flux, provisioned through
 
 ---
 
+## Next Steps
+
+### Add more services
+
+Beyond Flux, you can offer [Crossplane](https://www.crossplane.io/), [External Secrets Operator](https://external-secrets.io/), [Velero](https://velero.io/), and more to your teams. Each service is a [`ServiceProvider`](/developers/serviceprovider/deploy) deployed on the platform cluster.
+
+You can start to offer Crossplane to your development teams by applying this Service
+
+:::apply-to-platform
+
+```shell
+kubectl config use-context kind-local-platform
+kubectl apply -f - <<EOF
+apiVersion: openmcp.cloud/v1alpha1
+kind: ServiceProvider
+metadata:
+  name: crossplane
+  namespace: openmcp-system
+spec:
+  image: ghcr.io/openmcp-project/images/service-provider-crossplane:v1.0.1
+EOF
+```
+
+:::
+
+
+### Managed team access
+Learn how [Projects and Workspaces](/users/concepts/projects-and-workspaces) let you organize teams and `ControlPlanes`.
+
+:::note
+MORE COMING SOON
+:::
+
+### Deploy on real infrastrcture
+
+Follow the [Production Setup](./production-setup/00-overview.md) guide to run OpenControlPlane on Gardener.
+
+---
+
 ## Clean up
 
 ```shell
@@ -263,12 +302,3 @@ ocpctl env delete local
 
 Removes all Kind clusters and resources created by `ocpctl env apply local`.
 
----
-
-## Next Steps
-
-Your platform is running. Here's what to explore next:
-
-- **Add more services** — beyond Flux, you can offer [Crossplane](https://www.crossplane.io/), [External Secrets Operator](https://external-secrets.io/), [Velero](https://velero.io/), and more to your teams. Each service is a [`ServiceProvider`](/developers/serviceprovider/deploy) deployed on the platform cluster.
-- **Deploy on real infrastructure** — follow the [Production Setup](./production-setup/00-overview.md) guide to run OpenControlPlane on Gardener.
-- **Manage team access** — learn how [Projects and Workspaces](/users/concepts/projects-and-workspaces) let you organize teams and `ControlPlanes`.

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -43,7 +43,7 @@ The separation ensures end users never touch infrastructure. They interact only 
 ## Install ocpctl
 
 ```shell
-go install github.com/openmcp-project/ocpctl@v0.1.2
+go install github.com/openmcp-project/ocpctl@v0.1.3
 ```
 
 Or download a pre-built binary from the [releases page](https://github.com/openmcp-project/ocpctl/releases/latest).
@@ -56,7 +56,7 @@ Or download a pre-built binary from the [releases page](https://github.com/openm
 ocpctl env apply local
 ```
 
-This takes a few minutes. It creates a local Kind-based environment with the full OpenControlPlane stack: `openmcp-operator`, `cluster-provider-kind`, plus an onboarding cluster.
+This takes a few minutes. It creates a local Kind-based environment with the full OpenControlPlane stack: `openmcp-operator`, `cluster-provider-kind`, plus an onboarding cluster and pre-installed services that you can consume.
 
 Verify the platform is running:
 
@@ -71,45 +71,48 @@ You should see these pods in `Running` state:
 
 ```
 NAME                                      READY   STATUS      RESTARTS   AGE
-cp-kind-5cf448bb88-6nd2m                  1/1     Running     0          72s
-cp-kind-init-7c9fl                        0/1     Completed   0          83s
-openmcp-operator-5b7f788ddb-swq8j         1/1     Running     0          2m3s
-ps-helmdeployer-644d7454fc-9w852          1/1     Running     0          56s
-ps-helmdeployer-init-44z5k                0/1     Completed   0          87s
-ps-managedcontrolplane-7958959559-l55kg   1/1     Running     0          51s
-ps-managedcontrolplane-init-mkwnq         0/1     Completed   0          84s
+cp-kind-5cf448bb88-trj47                  1/1     Running     0          106s
+cp-kind-init-wxsbg                        0/1     Completed   0          113s
+openmcp-operator-5b7f788ddb-474tg         1/1     Running     0          2m15s
+ps-gateway-5db88d9474-6sxsp               1/1     Running     0          67s
+ps-gateway-init-hpjqq                     0/1     Completed   0          113s
+ps-helmdeployer-644d7454fc-zr2h5          1/1     Running     0          110s
+ps-helmdeployer-init-lmjxr                0/1     Completed   0          113s
+ps-managedcontrolplane-7958959559-tmlwf   1/1     Running     0          90s
+ps-managedcontrolplane-init-t46cn         0/1     Completed   0          113s
+sp-crossplane-84f8bbfb58-24lwl            1/1     Running     0          79s
+sp-crossplane-init-z657s                  0/1     Completed   0          113s
+sp-flux-844b667b9c-mhlqn                  1/1     Running     0          73s
+sp-flux-init-x5pxw                        0/1     Completed   0          112s
+sp-kro-ffbdcf787-zjrfz                    1/1     Running     0          83s
+sp-kro-init-rf5vk                         0/1     Completed   0          113s
+sp-ocm-756946b9dd-g67sd                   1/1     Running     0          70s
+sp-ocm-init-6cp5c                         0/1     Completed   0          111s
 ```
 
 :::
 
-### Install service-provider-flux
+In this output we can see that openmcp-operator and multiple other services like cluster-provider-kind (cp-kind) and service providers such as Crossplane, Flux, Kro and OCM are running.
 
-This guide uses Flux as an example managed service that teams can request for their `ControlPlane`. Managed service options are added to the platform as [ServiceProviders](/reference/operator/providers/serviceprovider).
+:::note Error
+We might see that Platform Service Gateway (`ps-gateway-5db88d9474-6sxsp`) has an ERROR.
+
+```shell
+...
+Error: applying resources: applying Unstructured//gateway: no matches for kind "GatewayServiceConfig" in version "gateway.openmcp.cloud/v1alpha1"
+```
+
+Please wait for a couple of seconds and then try execute `ocpctl env apply local` again. This will restart the Pod. All Pods above should be running eventually.
+:::
+
+### Configure allowed Flux versions
+
+In order that end users can request Flux getting installed in a `ControlPlane`, as Platform Owner, we need to make sure to configure allowed versions of Flux. We can configure them via a `ProviderConfig`:
 
 :::apply-to-platform
 
 ```shell
 flux install
-kubectl apply -f - <<EOF
-apiVersion: openmcp.cloud/v1alpha1
-kind: ServiceProvider
-metadata:
-  name: flux
-  namespace: openmcp-system
-spec:
-  image: ghcr.io/openmcp-project/images/service-provider-flux:v1.0.0
-EOF
-```
-
-:::
-
-### Configure allowed Flux versions
-
-Once `ServiceProvider` Flux is running, apply a `ProviderConfig` to define which Flux versions end users may install:
-
-:::apply-to-platform
-
-```shell
 kubectl apply -f - <<EOF
 apiVersion: flux.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
@@ -236,7 +239,7 @@ kubectl config use-context "kind-$CONTROLPLANE_CLUSTER"
 Flux installation can take a few minutes while the `ControlPlane` cluster finishes bootstrapping. Wait for all pods to reach `Running`:
 
 ```shell
-kubectl get pods -n flux-system -w
+kubectl get pods -n flux-system
 ```
 
 You should see Flux controllers running:
@@ -259,9 +262,30 @@ The team now has a fully functional control plane with Flux, provisioned through
 
 ### Add more services
 
-Beyond Flux, you can offer [Crossplane](https://www.crossplane.io/), [External Secrets Operator](https://external-secrets.io/), [Velero](https://velero.io/), and more to your teams. Each service is a [`ServiceProvider`](/developers/serviceprovider/deploy) deployed on the platform cluster.
+Beyond Flux, we can offer [Crossplane](https://www.crossplane.io/), [External Secrets Operator](https://external-secrets.io/), [Velero](https://velero.io/), and more to end users. Each service is a [`ServiceProvider`](/developers/serviceprovider/deploy) deployed on the platform cluster.
 
-You can start to offer Crossplane to your development teams by applying this Service
+Our CLI tool `ocpctl` already pre-installs a lot of these Service Providers. We can look them up via:
+
+:::apply-to-platform
+
+```shell
+kubectl config use-context kind-local-platform
+kubectl get serviceproviders
+```
+
+The output looks like this:
+
+```shell
+NAME         PHASE
+crossplane   Ready
+flux         Ready
+kro          Ready
+ocm          Ready
+```
+
+:::
+
+But we can also apply a new `ServiceProvider` to our platform to offer e.g. External Secrets Operator to end users:
 
 :::apply-to-platform
 
@@ -271,13 +295,36 @@ kubectl apply -f - <<EOF
 apiVersion: openmcp.cloud/v1alpha1
 kind: ServiceProvider
 metadata:
-  name: crossplane
+  name: externalsecretsoperator
   namespace: openmcp-system
 spec:
-  image: ghcr.io/openmcp-project/images/service-provider-crossplane:v1.0.1
+  image: ghcr.io/openmcp-project/images/service-provider-external-secrets:v1.0.0
 EOF
 ```
 
+We can look up the status of the installation by executing:
+```shell
+kubectl config use-context kind-local-platform
+kubectl get serviceproviders
+```
+
+The output looks like this:
+
+```shell
+NAME                      PHASE
+crossplane                Ready
+externalsecretsoperator   Progressing
+flux                      Ready
+kro                       Ready
+ocm                       Ready
+```
+
+:::
+
+Next, we need to configure these `ServiceProviders` via their `ProviderConfig` API to rule which versions end users can install.
+
+:::note
+MORE COMING SOON
 :::
 
 

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -154,7 +154,7 @@ See the [`ControlPlane` reference](/reference/core/controlplane) for the full AP
 ```shell
 kubectl config use-context kind-local-onboarding
 kubectl apply -f - <<EOF
-apiVersion: core.openmcp.cloud/v2alpha1
+apiVersion: core.open-control-plane.io/v2alpha1
 kind: ControlPlane
 metadata:
   name: my-controlplane

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -58,6 +58,17 @@ ocpctl env apply local
 
 This takes a few minutes. It creates a local Kind-based environment with the full OpenControlPlane stack: `openmcp-operator`, `cluster-provider-kind`, plus an onboarding cluster and pre-installed services that you can consume.
 
+:::note Error
+We might see that Platform Service Gateway (`ps-gateway-5db88d9474-6sxsp`) has an ERROR.
+
+```shell
+...
+Error: applying resources: applying Unstructured//gateway: no matches for kind "GatewayServiceConfig" in version "gateway.openmcp.cloud/v1alpha1"
+```
+
+Please wait for a couple of seconds and then try execute `ocpctl env apply local` again. This will restart the Pod. All Pods above should be running eventually.
+:::
+
 Verify the platform is running:
 
 :::apply-to-platform
@@ -70,40 +81,30 @@ kubectl get pods -n openmcp-system
 You should see these pods in `Running` state:
 
 ```
-NAME                                      READY   STATUS      RESTARTS   AGE
-cp-kind-5cf448bb88-trj47                  1/1     Running     0          106s
-cp-kind-init-wxsbg                        0/1     Completed   0          113s
-openmcp-operator-5b7f788ddb-474tg         1/1     Running     0          2m15s
-ps-gateway-5db88d9474-6sxsp               1/1     Running     0          67s
-ps-gateway-init-hpjqq                     0/1     Completed   0          113s
-ps-helmdeployer-644d7454fc-zr2h5          1/1     Running     0          110s
-ps-helmdeployer-init-lmjxr                0/1     Completed   0          113s
-ps-managedcontrolplane-7958959559-tmlwf   1/1     Running     0          90s
-ps-managedcontrolplane-init-t46cn         0/1     Completed   0          113s
-sp-crossplane-84f8bbfb58-24lwl            1/1     Running     0          79s
-sp-crossplane-init-z657s                  0/1     Completed   0          113s
-sp-flux-844b667b9c-mhlqn                  1/1     Running     0          73s
-sp-flux-init-x5pxw                        0/1     Completed   0          112s
-sp-kro-ffbdcf787-zjrfz                    1/1     Running     0          83s
-sp-kro-init-rf5vk                         0/1     Completed   0          113s
-sp-ocm-756946b9dd-g67sd                   1/1     Running     0          70s
-sp-ocm-init-6cp5c                         0/1     Completed   0          111s
+NAME                                      READY   STATUS      RESTARTS      AGE
+cp-kind-5cf448bb88-sx2vf                  1/1     Running     0             2m30s
+cp-kind-init-xfjb8                        0/1     Completed   0             2m49s
+openmcp-operator-5b7f788ddb-5r8br         1/1     Running     0             3m14s
+ps-gateway-5db88d9474-jkgg8               1/1     Running     4 (81s ago)   2m5s
+ps-gateway-init-j556q                     0/1     Completed   0             2m48s
+ps-helmdeployer-644d7454fc-nrlv9          1/1     Running     0             2m48s
+ps-helmdeployer-init-vq5ks                0/1     Completed   0             2m51s
+ps-managedcontrolplane-7958959559-vsrtr   1/1     Running     0             2m8s
+ps-managedcontrolplane-init-2lpkt         0/1     Completed   0             2m51s
+sp-crossplane-84f8bbfb58-265pf            1/1     Running     0             2m8s
+sp-crossplane-init-97c57                  0/1     Completed   0             2m49s
+sp-flux-844b667b9c-jbfqp                  1/1     Running     0             2m
+sp-flux-init-9w45m                        0/1     Completed   0             2m49s
+sp-kro-ffbdcf787-tst4z                    1/1     Running     0             96s
+sp-kro-init-sfcjb                         0/1     Completed   0             2m47s
+sp-ocm-756946b9dd-4djgn                   1/1     Running     0             113s
+sp-ocm-init-sh8x8                         0/1     Completed   0             2m49s
 ```
 
 :::
 
 In this output we can see that openmcp-operator and multiple other services like cluster-provider-kind (cp-kind) and service providers such as Crossplane, Flux, Kro and OCM are running.
 
-:::note Error
-We might see that Platform Service Gateway (`ps-gateway-5db88d9474-6sxsp`) has an ERROR.
-
-```shell
-...
-Error: applying resources: applying Unstructured//gateway: no matches for kind "GatewayServiceConfig" in version "gateway.openmcp.cloud/v1alpha1"
-```
-
-Please wait for a couple of seconds and then try execute `ocpctl env apply local` again. This will restart the Pod. All Pods above should be running eventually.
-:::
 
 ### Configure allowed Flux versions
 

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -169,8 +169,6 @@ spec:
 EOF
 ```
 
-:::
-
 Wait for it to become ready:
 
 ```shell
@@ -184,6 +182,7 @@ Once provisioning completes, you will see:
 NAME              PHASE
 my-controlplane   Ready
 ```
+:::
 
 The platform has provisioned an isolated `ControlPlane` cluster. Behind the scenes, OpenControlPlane asked `cluster-provider-kind` to create a new Kind cluster for this `ControlPlane`. The cluster is assigned a generated name of the form `mcp-<hash>.<random>` — for example `mcp-ad2klitc.f52190f9`. The hash is derived from the environment name; the suffix is random per provisioning run. You will need this name in Step 3.
 

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -336,7 +336,7 @@ Learn how [Projects and Workspaces](/users/concepts/projects-and-workspaces) let
 MORE COMING SOON
 :::
 
-### Deploy on real infrastrcture
+### Deploy on real infrastructure
 
 Follow the [Production Setup](./production-setup/00-overview.md) guide to run OpenControlPlane on Gardener.
 

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -131,16 +131,6 @@ EOF
 
 This controls exactly which versions teams can request in Step 3. Add more entries to the `versions` list to offer additional versions.
 
-:::note Error
-You might receive the following error message:
-
-```shell
-error: resource mapping not found for name: "flux" namespace: "" from "STDIN": no matches for kind "ProviderConfig" in version "flux.services.open-control-plane.io/v1alpha1"
-ensure CRDs are installed first
-```
-Please wait for a couple of seconds and then try again. Continue when the output says: `providerconfig.flux.services.open-control-plane.io/flux created`.
-:::
-
 ---
 
 ## Step 2: Create a ControlPlane

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -147,7 +147,7 @@ First, export the onboarding cluster's kubeconfig so `kubectl` can reach it:
 kind export kubeconfig --name local-onboarding
 ```
 
-See the [`ManagedControlPlaneV2` reference](/reference/core/controlplane) for the full API.
+See the [`ControlPlane` reference](/reference/core/controlplane) for the full API.
 
 :::apply-to-onboarding-api
 
@@ -155,7 +155,7 @@ See the [`ManagedControlPlaneV2` reference](/reference/core/controlplane) for th
 kubectl config use-context kind-local-onboarding
 kubectl apply -f - <<EOF
 apiVersion: core.openmcp.cloud/v2alpha1
-kind: ManagedControlPlaneV2
+kind: ControlPlane
 metadata:
   name: my-controlplane
   namespace: default
@@ -170,7 +170,7 @@ Wait for it to become ready:
 
 ```shell
 kubectl config use-context kind-local-onboarding
-kubectl get managedcontrolplanev2 my-controlplane -w
+kubectl get controlplane my-controlplane -w
 ```
 
 Once provisioning completes, you will see:

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -107,7 +107,7 @@ Please wait for a couple of seconds and then try execute `ocpctl env apply local
 
 ### Configure allowed Flux versions
 
-In order that end users can request Flux getting installed in a `ControlPlane`, as Platform Owner, we need to make sure to configure allowed versions of Flux. We can configure them via a `ProviderConfig`:
+To enable end users to request Flux for a `ControlPlane`, as Platform Owner, we need to make sure to configure allowed versions of Flux. We can configure them via a `ProviderConfig`:
 
 :::apply-to-platform
 

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -43,7 +43,7 @@ The separation ensures end users never touch infrastructure. They interact only 
 ## Install ocpctl
 
 ```shell
-go install github.com/openmcp-project/ocpctl@v0.1.0-alpha.1
+go install github.com/openmcp-project/ocpctl@v0.1.2
 ```
 
 Or download a pre-built binary from the [releases page](https://github.com/openmcp-project/ocpctl/releases/latest).
@@ -70,12 +70,14 @@ kubectl get pods -n openmcp-system
 You should see these pods in `Running` state:
 
 ```
-NAME                                     READY   STATUS      RESTARTS   AGE
-cp-kind-66fbf7d448-bd5xg                 1/1     Running     0          72s
-cp-kind-init-2zl9x                       0/1     Completed   0          83s
-openmcp-operator-d5c547c75-w5ngg         1/1     Running     0          2m3s
-ps-managedcontrolplane-9c848d7bc-49czl   1/1     Running     0          51s
-ps-managedcontrolplane-init-d7v4k        0/1     Completed   0          84s
+NAME                                      READY   STATUS      RESTARTS   AGE
+cp-kind-5cf448bb88-6nd2m                  1/1     Running     0          72s
+cp-kind-init-7c9fl                        0/1     Completed   0          83s
+openmcp-operator-5b7f788ddb-swq8j         1/1     Running     0          2m3s
+ps-helmdeployer-644d7454fc-9w852          1/1     Running     0          56s
+ps-helmdeployer-init-44z5k                0/1     Completed   0          87s
+ps-managedcontrolplane-7958959559-l55kg   1/1     Running     0          51s
+ps-managedcontrolplane-init-mkwnq         0/1     Completed   0          84s
 ```
 
 :::
@@ -95,7 +97,7 @@ metadata:
   name: flux
   namespace: openmcp-system
 spec:
-  image: ghcr.io/openmcp-project/images/service-provider-flux:v0.2.0
+  image: ghcr.io/openmcp-project/images/service-provider-flux:v1.0.0
 EOF
 ```
 
@@ -109,7 +111,7 @@ Once `ServiceProvider` Flux is running, apply a `ProviderConfig` to define which
 
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: flux.services.openmcp.cloud/v1alpha1
+apiVersion: flux.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: flux
@@ -193,7 +195,7 @@ The team wants Flux installed on their `ControlPlane`:
 ```shell
 kubectl config use-context kind-local-onboarding
 kubectl apply -f - <<EOF
-apiVersion: flux.services.openmcp.cloud/v1alpha1
+apiVersion: flux.services.open-control-plane.io/v1alpha1
 kind: Flux
 metadata:
   name: my-controlplane

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -238,11 +238,11 @@ kubectl config use-context "kind-$CONTROLPLANE_CLUSTER"
 
 Flux installation can take a few minutes while the `ControlPlane` cluster finishes bootstrapping. Wait for all pods to reach `Running`:
 
+:::apply-to-controlplane
+
 ```shell
 kubectl get pods -n flux-system
 ```
-
-You should see Flux controllers running:
 
 ```
 NAME                                           READY   STATUS    RESTARTS   AGE
@@ -253,6 +253,8 @@ kustomize-controller-7587bc49f9-m47nv          1/1     Running   0          2m8s
 notification-controller-d7d89cdb9-sht7p        1/1     Running   0          2m8s
 source-controller-7f6f4dd77d-vmxvv             1/1     Running   0          2m8s
 ```
+
+:::
 
 The team now has a fully functional control plane with Flux, provisioned through a simple API request.
 

--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -131,10 +131,10 @@ This controls exactly which versions teams can request in Step 3. Add more entri
 You might receive the following error message:
 
 ```shell
-error: resource mapping not found for name: "flux" namespace: "" from "STDIN": no matches for kind "ProviderConfig" in version "flux.services.openmcp.cloud/v1alpha1"
+error: resource mapping not found for name: "flux" namespace: "" from "STDIN": no matches for kind "ProviderConfig" in version "flux.services.open-control-plane.io/v1alpha1"
 ensure CRDs are installed first
 ```
-Please wait for a couple of seconds and then try again. Continue when the output says: `providerconfig.flux.services.openmcp.cloud/flux created`.
+Please wait for a couple of seconds and then try again. Continue when the output says: `providerconfig.flux.services.open-control-plane.io/flux created`.
 :::
 
 ---

--- a/docs/operators/how-to-guides/01-custom-ca.md
+++ b/docs/operators/how-to-guides/01-custom-ca.md
@@ -53,7 +53,7 @@ The following example uses the Crossplane service provider. Other service provid
 :::apply-to-platform
 
 ```yaml title="crossplane-provider-config.yaml"
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: default
@@ -87,7 +87,7 @@ kubectl describe configmap custom-ca-bundle -n openmcp-system
 Check that the ProviderConfig of each service provider has been accepted by the operator, e.g. for Crossplane:
 
 ```shell
-kubectl get providerconfigs.crossplane.services.openmcp.cloud -n openmcp-system
+kubectl get providerconfigs.crossplane.services.open-control-plane.io -n openmcp-system
 ```
 
 Service provider pods that were already running will restart automatically to pick up the new CA configuration. If a pod does not restart, delete it manually to trigger a fresh start.

--- a/docs/operators/production-setup/02-verify-setup.md
+++ b/docs/operators/production-setup/02-verify-setup.md
@@ -59,7 +59,7 @@ Create a file named `my-mcp.yaml` with the following content in the configuratio
 :::apply-to-onboarding-api
 
 ```yaml title="config/my-mcp.yaml"
-apiVersion: core.openmcp.cloud/v2alpha1
+apiVersion: core.open-control-plane.io/v2alpha1
 kind: ControlPlane
 metadata:
   name: my-mcp

--- a/docs/operators/production-setup/02-verify-setup.md
+++ b/docs/operators/production-setup/02-verify-setup.md
@@ -60,7 +60,7 @@ Create a file named `my-mcp.yaml` with the following content in the configuratio
 
 ```yaml title="config/my-mcp.yaml"
 apiVersion: core.openmcp.cloud/v2alpha1
-kind: ManagedControlPlaneV2
+kind: ControlPlane
 metadata:
   name: my-mcp
   namespace: default
@@ -81,7 +81,7 @@ The openmcp-operator should start to create the necessary resources in order to 
 Wait for it to become ready:
 
 ```shell
-kubectl --kubeconfig ./kubeconfigs/onboarding.kubeconfig get managedcontrolplanev2 -n default my-mcp -w
+kubectl --kubeconfig ./kubeconfigs/onboarding.kubeconfig get controlplane -n default my-mcp -w
 ```
 
 Once provisioning completes, you will see:

--- a/docs/reference/00-overview.md
+++ b/docs/reference/00-overview.md
@@ -17,7 +17,7 @@ Resources that end users interact with to consume platform capabilities.
   <div className="reference-icon-container reference-icon-container-standard">
     <img src="/img/cp2.png" alt="ControlPlane" className="reference-icon-large" />
   </div>
-  <h3>ManagedControlPlaneV2</h3>
+  <h3>ControlPlane</h3>
   <p>The primary resource for creating and managing control planes in OpenControlPlane.</p>
   <a href="/reference/core/controlplane" className="reference-link">View CRD →</a>
 </div>

--- a/docs/reference/core/controlplane.md
+++ b/docs/reference/core/controlplane.md
@@ -14,7 +14,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   </div>
 </div>
 
-**API Group:** `core.openmcp.cloud`
+**API Group:** `core.open-control-plane.io`
 **API Version:** `v2alpha1`
 **Kind:** `ControlPlane`
 
@@ -30,7 +30,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 Create a ControlPlane with IAM configuration:
 
 ```yaml
-apiVersion: core.openmcp.cloud/v2alpha1
+apiVersion: core.open-control-plane.io/v2alpha1
 kind: ControlPlane
 metadata:
   name: my-controlplane

--- a/docs/reference/core/controlplane.md
+++ b/docs/reference/core/controlplane.md
@@ -16,13 +16,13 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 
 **API Group:** `core.openmcp.cloud`
 **API Version:** `v2alpha1`
-**Kind:** `ManagedControlPlaneV2`
+**Kind:** `ControlPlane`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/openmcp-project/openmcp-operator/main/api/crds/manifests/core.openmcp.cloud_managedcontrolplanev2s.yaml"
-  name="ManagedControlPlaneV2"
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/openmcp-operator/main/api/crds/manifests/core.open-control-plane.io_controlplanes.yaml"
+  name="ControlPlane"
   description="Control plane management with IAM configuration"
-  exampleUrl="https://raw.githubusercontent.com/openmcp-project/openmcp-operator/main/internal/controllers/managedcontrolplane/testdata/test-01/onboarding/mcp-01.yaml"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/openmcp-operator/main/internal/controllers/controlplane/testdata/test-01/onboarding/mcp-01.yaml"
 />
 
 ## Usage
@@ -31,7 +31,7 @@ Create a ControlPlane with IAM configuration:
 
 ```yaml
 apiVersion: core.openmcp.cloud/v2alpha1
-kind: ManagedControlPlaneV2
+kind: ControlPlane
 metadata:
   name: my-controlplane
   namespace: default

--- a/docs/reference/core/project.md
+++ b/docs/reference/core/project.md
@@ -33,10 +33,10 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 **Kind:** `Project`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/openmcp-project/project-workspace-operator/main/api/crds/manifests/core.openmcp.cloud_projects.yaml"
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/platform-service-project-workspace/refs/heads/main/api/crds/manifests/core.openmcp.cloud_projects.yaml"
   name="Project"
   description="Project resource for multi-tenancy"
-  exampleUrl="https://raw.githubusercontent.com/openmcp-project/project-workspace-operator/main/config/samples/_v1alpha1_project.yaml"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/platform-service-project-workspace/refs/heads/main/config/samples/_v1alpha1_project.yaml"
 />
 
 ## Usage

--- a/docs/reference/core/workspace.md
+++ b/docs/reference/core/workspace.md
@@ -25,10 +25,10 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 **Kind:** `Workspace`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/openmcp-project/project-workspace-operator/main/api/crds/manifests/core.openmcp.cloud_workspaces.yaml"
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/platform-service-project-workspace/refs/heads/main/api/crds/manifests/core.openmcp.cloud_workspaces.yaml"
   name="Workspace"
   description="Workspace resource for environment isolation"
-  exampleUrl="https://raw.githubusercontent.com/openmcp-project/project-workspace-operator/main/config/samples/_v1alpha1_workspace.yaml"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/platform-service-project-workspace/refs/heads/main/config/samples/_v1alpha1_workspace.yaml"
 />
 
 ## Usage

--- a/docs/reference/operator/providers/serviceprovider.md
+++ b/docs/reference/operator/providers/serviceprovider.md
@@ -22,7 +22,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   crdUrl="https://raw.githubusercontent.com/openmcp-project/openmcp-operator/main/api/crds/manifests/openmcp.cloud_serviceproviders.yaml"
   name="ServiceProvider"
   description="Service delivery configuration"
-  exampleUrl="https://raw.githubusercontent.com/openmcp-project/openmcp-operator/main/internal/controllers/managedcontrolplane/testdata/test-01/platform/sp-01.yaml"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/openmcp-operator/main/internal/controllers/controlplane/testdata/test-01/platform/sp-01.yaml"
 />
 
 ## Related Resources

--- a/docs/reference/services/crossplane.md
+++ b/docs/reference/services/crossplane.md
@@ -14,12 +14,12 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   </div>
 </div>
 
-**API Group:** `crossplane.services.openmcp.cloud`
+**API Group:** `crossplane.services.open-control-plane.io`
 **API Version:** `v1alpha1`
 **Kind:** `Crossplane`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-crossplane/main/api/crds/manifests/crossplane.services.openmcp.cloud_crossplanes.yaml"
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-crossplane/main/api/crds/manifests/crossplane.services.open-control-plane.io_crossplanes.yaml"
   name="Crossplane"
   description="Crossplane service provider resource"
   exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-crossplane/main/config/samples/v1alpha1_crossplane.yaml"
@@ -30,7 +30,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 Deploy Crossplane within a control plane:
 
 ```yaml
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: Crossplane
 metadata:
   name: my-crossplane

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -14,12 +14,12 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   </div>
 </div>
 
-**API Group:** `kro.services.openmcp.cloud`
+**API Group:** `kro.services.open-control-plane.io`
 **API Version:** `v1alpha1`
 **Kind:** `Kro`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-kro/main/api/crds/manifests/kro.services.openmcp.cloud_kroes.yaml"
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-kro/main/api/crds/manifests/kro.services.open-control-plane.io_kroes.yaml"
   name="kro"
   description="kro service provider resource"
   exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-kro/main/test/e2e/onboarding/kro.yaml"
@@ -30,7 +30,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 Deploy kro within a control plane:
 
 ```yaml
-apiVersion: kro.services.openmcp.cloud/v1alpha1
+apiVersion: kro.services.open-control-plane.io/v1alpha1
 kind: Kro
 metadata:
   name: my-kro

--- a/docs/reference/services/landscaper.md
+++ b/docs/reference/services/landscaper.md
@@ -14,12 +14,12 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   </div>
 </div>
 
-**API Group:** `landscaper.services.openmcp.cloud`
+**API Group:** `landscaper.services.open-control-plane.io`
 **API Version:** `v1alpha2`
 **Kind:** `Landscaper`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-landscaper/main/api/crds/manifests/landscaper.services.openmcp.cloud_landscapers.yaml"
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-landscaper/main/api/crds/manifests/landscaper.services.open-control-plane.io_landscapers.yaml"
   name="Landscaper"
   description="Landscaper service provider resource"
   exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-landscaper/main/config/samples/v1alpha2_landscaper.yaml"
@@ -30,7 +30,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 Deploy Landscaper within a control plane:
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: Landscaper
 metadata:
   name: my-landscaper

--- a/docs/reference/services/landscaper.md
+++ b/docs/reference/services/landscaper.md
@@ -22,7 +22,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-landscaper/main/api/crds/manifests/landscaper.services.open-control-plane.io_landscapers.yaml"
   name="Landscaper"
   description="Landscaper service provider resource"
-  exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-landscaper/main/config/samples/v1alpha2_landscaper.yaml"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-landscaper/main/docs/resources/landscaper.yaml"
 />
 
 ## Usage

--- a/docs/reference/services/ocm.md
+++ b/docs/reference/services/ocm.md
@@ -14,12 +14,12 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   </div>
 </div>
 
-**API Group:** `ocm.services.openmcp.cloud`
+**API Group:** `ocm.services.open-control-plane.io`
 **API Version:** `v1alpha1`
 **Kind:** `OCM`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/open-component-model/service-provider-ocm/main/api/crds/manifests/ocm.services.openmcp.cloud_ocms.yaml"
+  crdUrl="https://raw.githubusercontent.com/open-component-model/service-provider-ocm/main/api/crds/manifests/ocm.services.open-control-plane.io_ocms.yaml"
   name="OCM"
   description="OCM service provider resource"
 />
@@ -29,7 +29,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 Deploy OCM within a control plane:
 
 ```yaml
-apiVersion: ocm.services.openmcp.cloud/v1alpha1
+apiVersion: ocm.services.open-control-plane.io/v1alpha1
 kind: OCM
 metadata:
   name: my-ocm

--- a/docs/reference/services/ocm.md
+++ b/docs/reference/services/ocm.md
@@ -22,6 +22,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   crdUrl="https://raw.githubusercontent.com/open-component-model/service-provider-ocm/main/api/crds/manifests/ocm.services.open-control-plane.io_ocms.yaml"
   name="OCM"
   description="OCM service provider resource"
+  exampleUrl="https://raw.githubusercontent.com/open-component-model/service-provider-ocm/main/test/e2e/onboarding/ocm.yaml"
 />
 
 ## Usage

--- a/docs/reference/services/velero.md
+++ b/docs/reference/services/velero.md
@@ -14,12 +14,12 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   </div>
 </div>
 
-**API Group:** `velero.services.openmcp.cloud`
+**API Group:** `velero.services.open-control-plane.io`
 **API Version:** `v1alpha1`
 **Kind:** `Velero`
 
 <CRDViewerCompact
-  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-velero/main/api/crds/manifests/velero.services.openmcp.cloud_veleroes.yaml"
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-velero/main/api/crds/manifests/velero.services.open-control-plane.io_veleroes.yaml"
   name="Velero"
   description="Velero service provider resource"
   exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-velero/main/config/samples/v1alpha1_velero.yaml"
@@ -30,7 +30,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
 Deploy Velero for backup and recovery:
 
 ```yaml
-apiVersion: velero.services.openmcp.cloud/v1alpha1
+apiVersion: velero.services.open-control-plane.io/v1alpha1
 kind: Velero
 metadata:
   name: backup-service

--- a/docs/reference/services/velero.md
+++ b/docs/reference/services/velero.md
@@ -22,7 +22,7 @@ import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
   crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-velero/main/api/crds/manifests/velero.services.open-control-plane.io_veleroes.yaml"
   name="Velero"
   description="Velero service provider resource"
-  exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-velero/main/config/samples/v1alpha1_velero.yaml"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-velero/main/test/e2e/onboarding/test-aws-a.yaml"
 />
 
 ## Usage

--- a/docs/users/getting-started/01-onboard.md
+++ b/docs/users/getting-started/01-onboard.md
@@ -219,7 +219,7 @@ Grab that namespace and continue with creating the ControlPlane resource.
 The `ControlPlane` resource is the heart of OpenControlPlane. Each ControlPlane has its own Kubernetes API endpoint and data store. You can use the `iam` property to define who can access the ControlPlane.
 
 ```yaml
-apiVersion: core.openmcp.cloud/v2alpha1
+apiVersion: core.open-control-plane.io/v2alpha1
 kind: ControlPlane
 metadata:
   name: my-controlplane
@@ -307,7 +307,7 @@ Name:         my-controlplane
 Namespace:    project-platform-team--ws-dev
 Labels:       <none>
 Annotations:  <none>
-API Version:  core.openmcp.cloud/v2alpha1
+API Version:  core.open-control-plane.io/v2alpha1
 Kind:         ControlPlane
 Metadata:
   Creation Timestamp:  2026-03-13T09:36:31Z

--- a/docs/users/getting-started/01-onboard.md
+++ b/docs/users/getting-started/01-onboard.md
@@ -220,7 +220,7 @@ The `ControlPlane` resource is the heart of OpenControlPlane. Each ControlPlane 
 
 ```yaml
 apiVersion: core.openmcp.cloud/v2alpha1
-kind: ManagedControlPlaneV2
+kind: ControlPlane
 metadata:
   name: my-controlplane
   namespace: project-platform-team--ws-dev
@@ -308,7 +308,7 @@ Namespace:    project-platform-team--ws-dev
 Labels:       <none>
 Annotations:  <none>
 API Version:  core.openmcp.cloud/v2alpha1
-Kind:         ManagedControlPlaneV2
+Kind:         ControlPlane
 Metadata:
   Creation Timestamp:  2026-03-13T09:36:31Z
   ...

--- a/docs/users/getting-started/02-connect.md
+++ b/docs/users/getting-started/02-connect.md
@@ -12,7 +12,7 @@ This guide shows you how to retrieve credentials and connect to your ControlPlan
 First, verify your ControlPlane is ready:
 
 ```bash
-kubectl get managedcontrolplanev2 my-controlplane -n project-platform-team--ws-dev
+kubectl get ControlPlane my-controlplane -n project-platform-team--ws-dev
 ```
 
 Wait until the ControlPlane shows a ready status. The `status.access` field contains references to your credentials.
@@ -25,7 +25,7 @@ The ControlPlane creates secrets containing kubeconfig files for each authentica
 
 ```bash
 # Get the secret name from status
-SECRET_NAME=$(kubectl get managedcontrolplanev2 my-controlplane \
+SECRET_NAME=$(kubectl get controlplane my-controlplane \
   -n project-platform-team--ws-dev \
   -o jsonpath='{.status.access.oidc.secretRef.name}')
 
@@ -38,7 +38,7 @@ kubectl get secret $SECRET_NAME -n project-platform-team--ws-dev \
 
 ```bash
 # Get the secret name from status
-SECRET_NAME=$(kubectl get managedcontrolplanev2 my-controlplane \
+SECRET_NAME=$(kubectl get controlplane my-controlplane \
   -n project-platform-team--ws-dev \
   -o jsonpath='{.status.access.tokens[0].secretRef.name}')
 

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -232,7 +232,7 @@ To install the Kro operator for your ControlPlane, create a `Kro` resource in th
 :::apply-to-onboarding-api
 
 ```yaml
-apiVersion: kro.services.open-control-plane.iov1alpha1
+apiVersion: kro.services.open-control-plane.io/v1alpha1
 kind: Kro
 metadata:
   name: my-controlplane

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -30,7 +30,7 @@ For each of these providers, the `name` of the managed service object **must** m
 To install Crossplane, create a `Crossplane` resource in the same namespace as your ControlPlane:
 
 ```yaml
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: Crossplane
 metadata:
   name: my-controlplane
@@ -56,7 +56,7 @@ kubectl apply -f crossplane.yaml
 To install Landscaper, create a `Landscaper` resource:
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: Landscaper
 metadata:
   name: my-controlplane
@@ -77,7 +77,7 @@ The [Open Component Model (OCM)](https://ocm.software/) toolset helps you delive
 To install the OCM operator for your ControlPlane, create an `OCM` resource in the same namespace and with the same name as your ControlPlane object:
 
 ```yaml
-apiVersion: ocm.services.openmcp.cloud/v1alpha1
+apiVersion: ocm.services.open-control-plane.io/v1alpha1
 kind: OCM
 metadata:
   name: my-controlplane
@@ -123,7 +123,7 @@ The base OCM installation comes with a bare minimum set of RBAC settings. To ext
 To install the Kro operator for your ControlPlane, create a `Kro` resource in the same namespace and with the same name as your ControlPlane object:
 
 ```yaml
-apiVersion: kro.services.openmcp.cloud/v1alpha1
+apiVersion: kro.services.open-control-plane.iov1alpha1
 kind: Kro
 metadata:
   name: my-controlplane

--- a/docs/users/getting-started/03-configure.md
+++ b/docs/users/getting-started/03-configure.md
@@ -29,6 +29,8 @@ For each of these providers, the `name` of the managed service object **must** m
 
 To install Crossplane, create a `Crossplane` resource in the same namespace as your ControlPlane:
 
+:::apply-to-onboarding-api
+
 ```yaml
 apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: Crossplane
@@ -42,11 +44,11 @@ spec:
       version: v0.16.0
 ```
 
-The `name` must match your ControlPlane name.
-
 ```bash
 kubectl apply -f crossplane.yaml
 ```
+
+:::
 
 </TabItem>
 <TabItem value="landscaper" label="Landscaper">
@@ -54,6 +56,8 @@ kubectl apply -f crossplane.yaml
 [Landscaper](https://github.com/gardener/landscaper) manages the installation, updates, and uninstallation of cloud-native workloads with complex dependency chains.
 
 To install Landscaper, create a `Landscaper` resource:
+
+:::apply-to-onboarding-api
 
 ```yaml
 apiVersion: landscaper.services.open-control-plane.io/v1alpha2
@@ -69,12 +73,16 @@ spec:
 kubectl apply -f landscaper.yaml
 ```
 
+:::
+
 </TabItem>
 <TabItem value="ocm" label="OCM">
 
 The [Open Component Model (OCM)](https://ocm.software/) toolset helps you deliver and deploy your software securely anywhere, at any scale. It's an open standard that defines deliverables in components that can be further processed, transferred, and verified to any location regardless of the technology of storage.
 
 To install the OCM operator for your ControlPlane, create an `OCM` resource in the same namespace and with the same name as your ControlPlane object:
+
+:::apply-to-onboarding-api
 
 ```yaml
 apiVersion: ocm.services.open-control-plane.io/v1alpha1
@@ -90,10 +98,13 @@ spec:
 kubectl apply -f ocm.yaml
 ```
 
+:::
+
 Once this object reconciles, you can verify the OCM controller is running on the ControlPlane:
 
+:::apply-to-controlplane
+
 ```bash
-# Make sure you are using the kubeconfig for the ControlPlane
 kubectl describe pod -n ocm-k8s-toolkit-system ocm-k8s-toolkit-controller-manager-
 ```
 
@@ -113,7 +124,103 @@ Events:
   Normal  Started    53s   kubelet            Started container manager
 ```
 
+:::
+
 The base OCM installation comes with a bare minimum set of RBAC settings. To extend this, follow the [custom RBAC for OCM](https://github.com/open-component-model/open-component-model/blob/main/kubernetes/controller/docs/getting-started/custom-rbac.md) guide. Since you are an admin on the ControlPlane, extending the service account's RBAC should work.
+
+</TabItem>
+<TabItem value="flux" label="Flux">
+
+[Flux](https://fluxcd.io/) is a GitOps toolkit for keeping Kubernetes clusters in sync with sources of configuration (like Git repositories) and automating updates to configuration when new code is deployed.
+
+To install Flux, create a `Flux` resource in the same namespace as your ControlPlane:
+
+:::apply-to-onboarding-api
+
+```yaml
+apiVersion: flux.services.open-control-plane.io/v1alpha1
+kind: Flux
+metadata:
+  name: my-controlplane
+  namespace: project-platform-team--ws-dev
+spec:
+  version: 2.8.3
+```
+
+```bash
+kubectl apply -f flux.yaml
+```
+
+:::
+
+Once this object reconciles, you can verify the Flux controllers are running on the ControlPlane:
+
+:::apply-to-controlplane
+
+```bash
+kubectl get pods -n flux-system
+```
+
+```
+NAME                                           READY   STATUS    RESTARTS   AGE
+helm-controller-8564d95f86-6kxlg               1/1     Running   0          2m
+kustomize-controller-7587bc49f9-m47nv          1/1     Running   0          2m
+source-controller-7f6f4dd77d-vmxvv             1/1     Running   0          2m
+```
+
+:::
+
+</TabItem>
+<TabItem value="velero" label="Velero">
+
+[Velero](https://velero.io/) provides backup and restore capabilities for your ControlPlane's workloads and persistent volumes, enabling disaster recovery and cluster migration.
+
+To install Velero, create a `Velero` resource in the same namespace as your ControlPlane:
+
+:::apply-to-onboarding-api
+
+```yaml
+apiVersion: velero.services.open-control-plane.io/v1alpha1
+kind: Velero
+metadata:
+  name: my-controlplane
+  namespace: project-platform-team--ws-dev
+spec:
+  version: v1.15.0
+```
+
+```bash
+kubectl apply -f velero.yaml
+```
+
+:::
+
+</TabItem>
+<TabItem value="external-secrets" label="External Secrets">
+
+[External Secrets Operator](https://external-secrets.io/) synchronizes secrets from external secret management systems (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, and others) into Kubernetes `Secret` objects on your ControlPlane.
+
+To install External Secrets Operator, create an `ExternalSecrets` resource in the same namespace as your ControlPlane:
+
+:::apply-to-onboarding-api
+
+```yaml
+apiVersion: externalsecrets.services.open-control-plane.io/v1alpha1
+kind: ExternalSecrets
+metadata:
+  name: my-controlplane
+  namespace: project-platform-team--ws-dev
+spec:
+  version: 0.14.0
+```
+
+```bash
+kubectl apply -f external-secrets.yaml
+```
+
+:::
+
+Once installed, you can create `SecretStore` and `ExternalSecret` resources on the ControlPlane to pull secrets from your chosen backend.
 
 </TabItem>
 <TabItem value="kro" label="Kro">
@@ -121,6 +228,8 @@ The base OCM installation comes with a bare minimum set of RBAC settings. To ext
 [Kro](https://kro.run) (Kube Resource Orchestrator) lets you create custom Kubernetes APIs by composing existing resources into higher-level abstractions. The service provider installs the Kro controller into the `kro-system` namespace on your ControlPlane via a Flux `HelmRelease`.
 
 To install the Kro operator for your ControlPlane, create a `Kro` resource in the same namespace and with the same name as your ControlPlane object:
+
+:::apply-to-onboarding-api
 
 ```yaml
 apiVersion: kro.services.open-control-plane.iov1alpha1
@@ -136,10 +245,13 @@ spec:
 kubectl apply -f kro.yaml
 ```
 
+:::
+
 Once this object reconciles, you can verify the Kro controller is running on the ControlPlane:
 
+:::apply-to-controlplane
+
 ```bash
-# Make sure you are using the kubeconfig for the ControlPlane
 kubectl get pods -n kro-system
 ```
 
@@ -147,6 +259,8 @@ kubectl get pods -n kro-system
 NAME                              READY   STATUS    RESTARTS   AGE
 kro-7d9c6f8b54-abcde              1/1     Running   0          45s
 ```
+
+:::
 
 The chart source, image pull secret, and Helm values are configured cluster-wide through the `ProviderConfig` maintained by your platform owner. See the [service-provider-kro README](https://github.com/openmcp-project/service-provider-kro#providerconfig) for the full set of tunables.
 
@@ -165,3 +279,6 @@ Congratulations! You have a working ControlPlane with managed services. Here's w
 - **[Landscaper Service Provider](https://github.com/openmcp-project/service-provider-landscaper)** — Orchestrate complex workloads
 - **[OCM Service Provider](https://github.com/open-component-model/service-provider-ocm)** — Deliver and deploy software with the Open Component Model
 - **[Kro Service Provider](https://github.com/openmcp-project/service-provider-kro)** — Compose custom Kubernetes APIs with Kro
+- **[Flux Service Provider](https://github.com/openmcp-project/service-provider-flux)** — GitOps-driven continuous delivery
+- **[Velero Service Provider](https://github.com/openmcp-project/service-provider-velero)** — Backup and disaster recovery
+- **[External Secrets Service Provider](https://github.com/openmcp-project/service-provider-external-secrets)** — Sync secrets from external vaults

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -757,21 +757,21 @@ export default function Home() {
                 <div className={`essentials-visual-content ${activeFeature === 0 ? 'active' : ''}`}>
                   <div className="yaml-left-container">
                     <pre className="essentials-yaml-unified">
-{`apiVersion: openmcp.cloud/v1alpha1
-kind: ManagedControlPlane
+{`apiVersion: core.open-control-plane.io/v2alpha1
+kind: ControlPlane
 metadata:
   name: team-prod
 spec:
   provider: gardener
 ---
-apiVersion: openmcp.cloud/v1alpha1
+apiVersion: open-control-plane.io/v1alpha1
 kind: Database
 metadata:
   name: prod-db
 spec:
   engine: postgresql
 ---
-apiVersion: openmcp.cloud/v1alpha1
+apiVersion: open-control-plane.io/v1alpha1
 kind: Subaccount
 metadata:
   name: team-alpha


### PR DESCRIPTION
**What this PR does / why we need it**:

- Rename `ManagedControlPlane` → `ControlPlane` and `*.openmcp.cloud` → `*.open-control-plane.io` across all YAML snippets and reference pages (core + all service providers)
- Rename `platformservice` → `platformprovider` in the developers section
- Expand quickstart: updated pod list, new "What's next" section with Crossplane example and structured next steps
- Expand configure guide: add Flux, Velero, and External Secrets tabs
- Update reference links: Project/Workspace CRDs now point to `platform-service-project-workspace` repo; ServiceProvider example path uses `controlplane`
- Bump `ocpctl` install version to `v0.1.3`
- Bump Node in deploy workflows

**Which issue(s) this PR fixes**:
Fixes #50

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
Update quickstart, configure guide, and API references to reflect renamed kinds and API groups.
```