### PR TITLE
fix(crd-viewer): use named import for js-yaml load

### DIFF
--- a/src/components/CRDViewer/index.js
+++ b/src/components/CRDViewer/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import yaml from 'js-yaml';
+import { load as yamlLoad } from 'js-yaml';
 
 export default function CRDViewer({ crdUrl, name, description, exampleUrl }) {
   const [crdData, setCrdData] = useState(null);
@@ -21,7 +21,7 @@ export default function CRDViewer({ crdUrl, name, description, exampleUrl }) {
         setCrdData(crdText);
 
         // Parse CRD YAML to extract OpenAPI schema
-        const crdObject = yaml.load(crdText);
+        const crdObject = yamlLoad(crdText);
         const specSchema = crdObject?.spec?.versions?.[0]?.schema?.openAPIV3Schema?.properties?.spec;
 
         if (specSchema) {

--- a/src/components/CRDViewerCompact/index.js
+++ b/src/components/CRDViewerCompact/index.js
@@ -3,7 +3,7 @@ import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { Search } from 'lucide-react';
-import yaml from 'js-yaml';
+import { load as yamlLoad } from 'js-yaml';
 
 const SchemaField = ({ field, depth = 0, searchTerm }) => {
   const hasChildren = field.children && field.children.length > 0;
@@ -91,7 +91,7 @@ export default function CRDViewerCompact({ crdUrl, name, description, exampleUrl
         const crdText = await crdResponse.text();
         setCrdData(crdText);
 
-        const crdObject = yaml.load(crdText);
+        const crdObject = yamlLoad(crdText);
         const specSchema = crdObject?.spec?.versions?.[0]?.schema?.openAPIV3Schema?.properties?.spec;
         const statusSchema = crdObject?.spec?.versions?.[0]?.schema?.openAPIV3Schema?.properties?.status;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the CRD browser showing `Error loading CRD: Cannot read properties of undefined (reading 'load')` on the production site.

The js-yaml v5 upgrade (#146) added an ESM entry point. Webpack's production bundler resolves this and its `default` export collapses to `undefined` due to a double interop chain (CJS wrapped in ESM). The dev server is unaffected.

Using a named import (`import { load as yamlLoad } from 'js-yaml'`) bypasses the broken default export chain entirely.

**Which issue(s) this PR fixes**:
Regression introduced by #146

**Special notes for your reviewer**:
The bug only shows in the production build, not the dev server. That's why it wasn't caught before merging #146.

**Release note**:
```bugfix user
Fixed CRD browser showing "Error loading CRD" on all reference pages.
```