### PR TITLE
fix(ci): add concurrency group to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Docusaurus


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `concurrency` group to the deploy workflow so that a new deploy cancels any in-progress one instead of failing. Without this, when two pushes to `main` land close together (e.g. back-to-back Renovate merges), both deploy jobs run in parallel. GitHub Pages only allows one active deployment at a time, causing the second to fail immediately with a 400 or a terminal `deployment_failed` status.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`cancel-in-progress: true` means the older deploy is cancelled when a newer one starts — the latest commit always wins, which is the correct behaviour for a docs site.

**Release note**:
```other developer
NONE
```