### PR TITLE
fix(ci): add explicit permissions to workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 concurrency:
   group: github-pages
   cancel-in-progress: true

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -11,6 +11,8 @@ jobs:
   test-deploy:
     name: Test deployment
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` at workflow level in `deploy.yml` (the `deploy` job already has its own `pages: write` + `id-token: write` override)
- Adds `permissions: contents: read` at job level in `test-deploy.yml`

## Fixes
Resolves [code-scan alerts #9 and #10](https://github.com/openmcp-project/docs/security/code-scanning) (`actions/missing-workflow-permissions`)

## Test plan
- [x] CI passes on this PR (`test-deploy.yml`)
- [ ] Merge to main triggers successful Pages deploy (`deploy.yml`)