### PR TITLE
chore(quickstart): upgrade ocpctl version to v0.2.0

### DIFF
--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -43,7 +43,7 @@ The separation ensures end users never touch infrastructure. They interact only 
 ## Install ocpctl
 
 ```shell
-go install github.com/openmcp-project/ocpctl@v0.1.4
+go install github.com/openmcp-project/ocpctl@v0.2.0
 ```
 
 Or download a pre-built binary from the [releases page](https://github.com/openmcp-project/ocpctl/releases/latest).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simply updates the ocpctl version in the quickstart guide to v0.2.0 according to: https://github.com/openmcp-project/ocpctl/releases/tag/v0.2.0

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```