### PR TITLE
docs(platform-services): deployment and examples

### DIFF
--- a/docs/developers/clusterprovider/01-design.mdx
+++ b/docs/developers/clusterprovider/01-design.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 1
 id: design
 ---
 
@@ -11,4 +11,4 @@ Detailed design documentation for Cluster Providers is coming soon.
 
 Cluster Providers are responsible for managing Kubernetes clusters and providing access to them within the OpenControlPlane ecosystem. They follow similar architectural patterns to Service Providers.
 
-For reference, you can review the [Service Provider Design Documentation](../serviceprovider/01-design.mdx) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.
+For reference, you can review the [Service Provider Design Documentation](../serviceprovider/design) which outlines concepts that apply to all provider types in the OpenControlPlane ecosystem.

--- a/docs/developers/clusterprovider/02-develop.mdx
+++ b/docs/developers/clusterprovider/02-develop.mdx
@@ -13,8 +13,8 @@ Cluster Providers manage Kubernetes clusters and provide access to them within t
 
 For now, you can:
 - Review existing implementations: [cluster-provider-gardener](https://github.com/openmcp-project/cluster-provider-gardener) and [cluster-provider-kind](https://github.com/openmcp-project/cluster-provider-kind)
-- Refer to the [Deploy Guide](./01-deployment.mdx) for the common deployment contract
-- Check the [Service Provider Develop Guide](../serviceprovider/02-develop.mdx) for general patterns that apply to all provider types
+- Refer to the [Deploy Guide](./deploy) for the common deployment contract
+- Check the [Service Provider Develop Guide](../serviceprovider/develop) for general patterns that apply to all provider types
 
 ## Implementing a ClusterProvider
 

--- a/docs/developers/clusterprovider/03-deployment.mdx
+++ b/docs/developers/clusterprovider/03-deployment.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 id: deploy
 ---
 

--- a/docs/developers/clusterprovider/04-examples.mdx
+++ b/docs/developers/clusterprovider/04-examples.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 id: examples
 ---
 
@@ -39,6 +39,6 @@ Cluster Providers that manage Kubernetes clusters within OpenControlPlane. Use t
 
 </div>
 
-These projects serve as reference implementations for building Cluster Providers. Check out the [Deploy Guide](./01-deployment.mdx) to create your own, or contribute improvements to existing providers.
+These projects serve as reference implementations for building Cluster Providers. Check out the [Deploy Guide](./deploy) to create your own, or contribute improvements to existing providers.
 
 **Want to get involved?** Join our developer community through [SIG Extensibility](https://github.com/openmcp-project/community/tree/main/sig-extensibility) - see the [Build Together overview](../overview#join-the-community) for details on how to connect with other provider developers.

--- a/docs/developers/platformservice/01-design.mdx
+++ b/docs/developers/platformservice/01-design.mdx
@@ -9,14 +9,14 @@ This document defines the terminology for Platform Services within the OpenContr
 
 ## Domain
 
-Platform services deliver platform capabilities within the OpenControlPlane ecosystem. They follow similar architectural patterns to [Service Providers](../serviceprovider/01-design.mdx) and [Cluster Providers](../clusterprovider/04-design.mdx).
+Platform services deliver platform capabilities within the OpenControlPlane ecosystem. They follow similar architectural patterns to [Service Providers](../serviceprovider/design) and [Cluster Providers](../clusterprovider/design).
 
-When mapped to a layered architecture using the personas of **Platform Owner**, **Service Provider** and **User**, Platform Services operate in the **Platform Owner** layer. Together with [Cluster Providers](../clusterprovider/04-design.mdx) they build the foundation of OpenControlPlane:
+When mapped to a layered architecture using the personas of **Platform Owner**, **Service Provider** and **User**, Platform Services operate in the **Platform Owner** layer. Together with [Cluster Providers](../clusterprovider/design) they build the foundation of OpenControlPlane:
 
 | Persona | OpenControlPlane Concept | Responsibility |
 | :------ | :--------------- | :------------------- |
-| Platform Owner | Platform Service and [Cluster Provider](../clusterprovider/04-design.mdx) | Provide platform capabilities consumed by the layers below |
-| Service Provider | [Service Providers](../serviceprovider/01-design.mdx) | Provide managed services consumed by the layer below |
+| Platform Owner | Platform Service and [Cluster Provider](../clusterprovider/design) | Provide platform capabilities consumed by the layers below |
+| Service Provider | [Service Providers](../serviceprovider/design) | Provide managed services consumed by the layer below |
 | User | Not an OpenControlPlane concept but a human end user | Generate value from the services provided by Platform Owners and Service Providers |
 
 Some Platform Services are required to operate OpenControlPlane, such as those included in the [openmcp-operator](https://github.com/openmcp-project/openmcp-operator). Others are optional and extend the platform's capabilities to support specific use cases.
@@ -99,5 +99,5 @@ The following table distinguishes Platform Services and Service Providers based 
 ❌ MUST NOT introduce API on that cluster type.
 
 :::info
-Note that the Service Provider [Config](../serviceprovider/01-design.mdx#config) is not considered a service.
+Note that the Service Provider [Config](../serviceprovider/design#config) is not considered a service.
 :::

--- a/docs/developers/platformservice/03-deployment.mdx
+++ b/docs/developers/platformservice/03-deployment.mdx
@@ -5,8 +5,87 @@ id: deploy
 
 # Deploy
 
-:::info Coming Soon
-Documentation for deploying Platform Services is coming soon. Platform Services follow the same deployment contract as Service Providers and Cluster Providers.
-:::
+Platform Services provide platform capabilities that can be consumed by service providers and/or users within the OpenControlPlane ecosystem.
 
-For now, please refer to the [Service Provider Deploy Guide](../serviceprovider/05-deployment.mdx) for the common deployment contract that applies to all provider types.
+They can automatically be deployed via the `PlatformService` resource. The [openmcp-operator](https://github.com/openmcp-project/openmcp-operator) is responsible for these resources.
+
+All providers are cluster-scoped resources.
+
+## Example `PlatformService` resource
+
+```yaml
+apiVersion: openmcp.cloud/v1alpha1
+kind: PlatformService
+metadata:
+  name: example-service
+spec:
+  image: ghcr.io/openmcp-project/images/platform-service-example:v1.0.0
+  verbosity: INFO
+```
+
+## Common Provider Contract
+
+All provider types (`ClusterProviders`, `ServiceProviders`, `PlatformServices`) follow the same deployment contract.
+
+### Executing the Binary
+
+#### Image
+
+Each provider implementation must provide a container image with the provider binary set as an entrypoint.
+
+#### Subcommands
+
+The provider binary must take two subcommands:
+- `init` initializes the provider. This usually means deploying CRDs for custom resources used by the controller(s).
+  - The `init` subcommand is executed as a job once whenever the deployed version of the provider changes.
+- `run` runs the actual controller(s) required for the provider.
+  - The `run` subcommand is executed in a pod as part of a deployment.
+  - The pods with the `run` command are only started after the init job has successfully run through.
+  - It may be run multiple times in parallel (high-availability), so the provider implementation should support this, e.g. via leader election.
+
+#### Arguments
+
+Both subcommands take the same arguments, which are explained below. These arguments will always be passed into the provider.
+- `--environment` *any lowercase string*
+  - The *environment* argument is meant to distinguish between multiple environments (=platform clusters) watching the same onboarding cluster. For example, there could be a public environment and another fenced one - both watch the same resources on the same cluster, but only one of them is meant to react on each resource, depending on its configuration.
+  - Most setups will probably use only a single environment.
+  - Will likely be set to the landscape name (e.g. `canary`, `live`) most of the time.
+- `--provider-name` *any lowercase string*
+  - This argument contains the name of the k8s provider resource from which this pod was created.
+  - If ever multiple instances of the same provider are deployed in the same landscape, this value can be used to differentiate between them.
+- `--verbosity` or `-v` *enum: ERROR, INFO, or DEBUG*
+  - This value specifies the desired logging verbosity for the provider.
+
+#### Environment Variables
+
+The following environment variables can be expected to be set:
+- `POD_NAME`
+  - Name of the pod the provider binary runs in.
+- `POD_NAMESPACE`
+  - Namespace of the pod the provider binary runs in.
+- `POD_IP`
+  - IP address of the pod the provider binary runs in.
+- `POD_SERVICE_ACCOUNT_NAME`
+  - Name of the service account that is used to run the provider.
+
+#### Customizations
+
+While it is possible to customize some aspects of how the provider binary is executed, such as adding additional environment variables, overwriting the subcommands, adding additional arguments, etc., this should only be done in exceptional cases to keep the complexity of setting up an OpenControlPlane landscape as low as possible.
+
+### Configuration
+
+Passing configuration into the provider binary via a command-line argument is not desired. If the provider requires configuration of some kind, it is expected to read it from one or more k8s resources, potentially even running a controller to reconcile these resources. The `init` subcommand can be used to register the CRDs for the configuration resources, although this leads to the disadvantage of the configuration resource only been known after the provider has already been started, which can cause problems with gitOps (or similar deployment methods that deploy all resources at the same time).
+
+### Tips and Tricks
+
+#### Getting Access to the Onboarding Cluster
+
+Providers generally live in the platform cluster, so they can simply access it by using the in-cluster configuration. Getting access to the onboarding cluster is a little bit more tricky: First, the `Cluster` resource of the onboarding cluster itself or any `ClusterRequest` pointing to it is required. The provider can simply create its own `ClusterRequest` with purpose `onboarding` - a little trick that is possible due to the shared nature of the onboarding cluster, all requests to it will result in a reference to the same `Cluster`. Then, the provider needs to create an `AccessRequest` with the desired permissions and wait until it is ready. This will result in a secret containing a kubeconfig for the onboarding cluster.
+
+This flow is already implemented in the library function [`CreateAndWaitForCluster](https://github.com/openmcp-project/openmcp-operator/blob/v0.11.2/lib/clusteraccess/clusteraccess.go#L387).
+
+## Deployment Example
+
+The `PlatformService` resource above will result in similar `Job` and `Deployment` resources as [ClusterProviders](../clusterprovider/deploy#deployment-example), with the main difference being the `kind: PlatformService` annotation and corresponding labels.
+
+The deployment structure follows the same pattern with an init job for CRD installation and a controller deployment for the actual service provider logic.

--- a/docs/developers/platformservice/04-examples.mdx
+++ b/docs/developers/platformservice/04-examples.mdx
@@ -5,8 +5,111 @@ id: examples
 
 # Examples
 
-:::info Coming Soon
-Platform Services examples and templates are coming soon.
-:::
+Platform Services that deliver platform capabilities within OpenControlPlane. Use these as inspiration to build your own integrations or contribute improvements.
 
-Platform Services deliver complete platform capabilities within OpenControlPlane. Stay tuned for official examples and reference implementations.
+## Official Platform Services
+
+<div className="ecosystem-grid">
+
+<div className="project-card">
+  <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="project-logo"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    <h3>platform-service-quota</h3>
+  </div>
+  <div className="project-description">
+    A Kubernetes Operator for managing resource quotas in namespaces.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/platform-service-quota" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a>
+  </div>
+</div>
+
+<div className="project-card">
+  <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="project-logo"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    <h3>platform-service-project-workspace</h3>
+  </div>
+  <div className="project-description">
+    Part of the onboarding system that reconciles Project and Workspace resources.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/platform-service-project-workspace" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a>
+  </div>
+</div>
+
+<div className="project-card">
+  <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="project-logo"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    <h3>platform-service-test-runner</h3>
+  </div>
+  <div className="project-description">
+    A platform service to define and run in-cluster tests on OpenControlPlane clusters.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/platform-service-test-runner" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a>
+  </div>
+</div>
+
+<div className="project-card">
+  <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="project-logo"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    <h3>platform-service-gateway</h3>
+  </div>
+  <div className="project-description">
+    Platform Service Gateway enables communication across different Kubernetes clusters.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/platform-service-gateway" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a>
+  </div>
+</div>
+
+<div className="project-card">
+  <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="project-logo"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    <h3>platform-service-dns</h3>
+  </div>
+  <div className="project-description">
+    Platform Service DNS discovers endpoints of remote services.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/platform-service-dns" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a>
+  </div>
+</div>
+
+<div className="project-card">
+  <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="project-logo"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    <h3>platform-service-gardener-ipam</h3>
+  </div>
+  <div className="project-description">
+    A platform service to manage and inject CIDRs for ClusterProvider Gardener.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/platform-service-gardener-ipam" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a>
+  </div>
+</div>
+
+</div>
+
+## Community Platform Services
+
+<div className="ecosystem-grid">
+
+<div className="project-card project-card-cta">
+  <div className="project-card-header">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+    <h3>Build Your Own</h3>
+  </div>
+  <div className="project-description">
+    Use our template to create your own Platform Service and contribute it to the community.
+  </div>
+  <div className="project-links">
+    <a href="https://github.com/openmcp-project/platform-service-template" className="project-link project-link-primary" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> Template Repository</a>
+  </div>
+</div>
+
+</div>
+
+These projects serve as reference implementations for building Service Providers. Check out the [Deploy Guide](deploy) to create your own, or contribute improvements to existing providers.
+
+**Want to get involved?** Join our developer community through [SIG Extensibility](https://github.com/openmcp-project/community/tree/main/sig-extensibility) - see the [Build Together overview](../overview#join-the-community) for details on how to connect with other provider developers.

--- a/docs/developers/serviceprovider/how-to-guides/01-custom-ca.md
+++ b/docs/developers/serviceprovider/how-to-guides/01-custom-ca.md
@@ -7,7 +7,7 @@ This guide covers the developer side. For the operator side (creating the CA bun
 ## Prerequisites
 
 - A service provider created from the [service-provider-template](https://github.com/openmcp-project/service-provider-template)
-- Familiarity with the [ProviderConfig design guidelines](../02-develop.mdx#edit-the-providerconfig-api)
+- Familiarity with the [ProviderConfig design guidelines](../develop#edit-the-providerconfig-api)
 
 ## Step 1 — Add `caBundleRef` to your ProviderConfig API
 


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
1. Adds missing platform service sections "deployment" and "examples".
2. Aligns cluster provider ordering with platform services and service providers.
3. Replaces file references with id for stable links.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```