### PR TITLE
docs(serviceprovider): update status struct examples to use commonapi.Status inline

### DIFF
--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -132,7 +132,7 @@ spec:
       version: "v1.13.0"
 ```
 
-Each onboarding API type must include [common status fields](https://openmcp-project.github.io/docs/developers/general/#status-reporting). These are included in the template via the `commonapi.Status` inline struct and you can add additional optional fields.
+Each onboarding API type must include [common status fields](/developers/general#status-reporting). These are included in the template via the `commonapi.Status` inline struct and you can add additional optional fields.
 
 ```go
 import (

--- a/docs/developers/serviceprovider/02-develop.mdx
+++ b/docs/developers/serviceprovider/02-develop.mdx
@@ -132,20 +132,16 @@ spec:
       version: "v1.13.0"
 ```
 
-Each onboarding API type must include [common status fields](https://openmcp-project.github.io/docs/developers/general/#status-reporting). These are included in the template and you can add additional optional fields.
+Each onboarding API type must include [common status fields](https://openmcp-project.github.io/docs/developers/general/#status-reporting). These are included in the template via the `commonapi.Status` inline struct and you can add additional optional fields.
 
 ```go
+import (
+ commonapi "github.com/openmcp-project/openmcp-operator/api/common"
+)
+
 // FooServiceStatus defines the observed state of FooService.
 type FooServiceStatus struct {
- // The status of each condition is one of True, False, or Unknown.
- // +listType=map
- // +listMapKey=type
- // +optional
- Conditions []metav1.Condition `json:"conditions,omitempty"`
- // ObservedGeneration is the generation of this resource that was last reconciled by the controller.
- ObservedGeneration int64 `json:"observedGeneration"`
- // Phase is the current phase of the resource.
- Phase string `json:"phase"`
+ commonapi.Status `json:",inline"`
 }
 ```
 
@@ -163,15 +159,7 @@ const (
 )
 
 type VeleroStatus struct {
- // The status of each condition is one of True, False, or Unknown.
- // +listType=map
- // +listMapKey=type
- // +optional
- Conditions []metav1.Condition `json:"conditions,omitempty"`
- // ObservedGeneration is the generation of this resource that was last reconciled by the controller.
- ObservedGeneration int64 `json:"observedGeneration"`
- // Phase is the current phase of the resource.
- Phase string `json:"phase"`
+ commonapi.Status `json:",inline"`
  // Resources managed by this velero instance
  // +optional
  Resources []ManagedResource `json:"resources,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the status struct code examples in the service provider development guide to reflect the current template. Since [openmcp-operator#326](https://github.com/openmcp-project/openmcp-operator/pull/326) added `+listType=map` to `commonapi.Status.Conditions` and [service-provider-template#107](https://github.com/openmcp-project/service-provider-template/pull/107) updated the template to embed `commonapi.Status` inline, the examples in `02-develop.mdx` were showing the old boilerplate fields (`Conditions`, `ObservedGeneration`, `Phase`) instead of the single inline embed.

**Which issue(s) this PR fixes**:
Follow-up to https://github.com/openmcp-project/openmcp-operator/pull/326 and https://github.com/openmcp-project/service-provider-template/pull/107

**Special notes for your reviewer**:
The `VeleroStatus` example retains its extra `Resources` field, only the common status fields are replaced with the inline embed.

**Release note**:
```doc developer
Update status struct examples in service provider guide to use commonapi.Status inline embed
```