### PR TITLE
fix(deps): resolve serialize-javascript and uuid CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,16 +30,53 @@
         "node": ">=18.0"
       }
     },
-    "node_modules/@algolia/abtesting": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.1.tgz",
-      "integrity": "sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==",
+    "node_modules/@11ty/gray-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/gray-matter/-/gray-matter-1.0.0.tgz",
+      "integrity": "sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "js-yaml": "^4.1.0",
+        "kind-of": "^6.0.3",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@11ty/gray-matter/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.2.tgz",
+      "integrity": "sha512-uXj0rgk30EpsKvOpuS+R+1XFDrnm56hED1Lz56e8uBkZdKCxw99LS2U8eXBqAHYU8kpkbsnV1GC8velBG070Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -78,99 +115,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.1.tgz",
-      "integrity": "sha512-miW8RzAtBgNiEJ9fGEhsOPgWUpekAe64YcVufqXrlykj0Jjmo5nj0a5f/HAzRVX5ZuU1GAVd7BkzFDx7q50P3A==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.2.tgz",
+      "integrity": "sha512-y7Epol8HcjlBxKXHhyhfFPFhm78B3P6x9cCbCyGTdxjsdVCptXCy5hpkZWxjGpnaLHvWsHS4QRF0TiBOLst2xg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.1.tgz",
-      "integrity": "sha512-eR3J3kB9JX6DdCvDRi3I4KPfwO6fR9HWYRXhVke2TXIoOQafMKCRAneg33JRmIrb+DnnJ/eWApJLF1O1CLPERg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.2.tgz",
+      "integrity": "sha512-8Pxj2VVmpM2d+UZufnlTq7T1QIcYPVugLV5XC50PnHsV5uRM9CSoYkg2Y+CwqwRk2La0xK5QsfZ0obIU+9XftQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.1.tgz",
-      "integrity": "sha512-P5ak7EurwYqgAiDyb95mgA3WRR/Zu8CPMv36lWTISvL2AmlPyqQPy2nX/KEJRTcwaeTWwrk6wJV4/M93GfjOWw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.2.tgz",
+      "integrity": "sha512-9L4IpIYUqA63a7sw1trnHQGUvwiAjKz67nsgDnal98JGAc7wyposRb0Iag+eiMuyzFFaSHLe2/rGyIo+PafRBA==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.1.tgz",
-      "integrity": "sha512-OVtj9uA//+pjvKQI5INnzbyLrf3ClNv3XRbWswwJ2kHIStQNHtBfHo+LofNB/WhM9xjuXlW5ANn2aMj65UGx7w==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.2.tgz",
+      "integrity": "sha512-ZBm2ytY5EHFcj+kjNsXxMNO/TGlOHe2fBFXGKHJOM1bk1rAy4o2YI+d9oV/w/jrqx44pvJMJlc8X6vKnCuDgUQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.1.tgz",
-      "integrity": "sha512-oKlVFlp+qbIEe4p7E54zSiP2gEV/vDu972Ykv8VDMFwEvreS7m0YKA3a8hGGHwc7yiBUGGiR3LlwzMLfnJmy6Q==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.2.tgz",
+      "integrity": "sha512-3FGVW/jDk7sdYwqa2NKnF/qXWcttc4bvGrwNbvqz3VoWSRv42CNvRk+3Y9QJFIUf1vY50hAuVWUoFKdyc8vaXA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.1.tgz",
-      "integrity": "sha512-BOVrld6vdtsFmotVDMTVQfYXwrVplJ+DUvy60JFi+tkWV698q2J9NNPKEO3dr5qxtSLKQP4vHF8n+3U5PDWhOQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.2.tgz",
+      "integrity": "sha512-JsG8LovDAYul5t8e533tZ3O1uZILxso5zsTtB7ONc5RJ8ACdTxAAC/jaOnsBNYb+x+STP7fzx/Iro55v5DNgoQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.1.tgz",
-      "integrity": "sha512-GAqHl9zERhC3bbBfubwUu07G3UXO06gORvOcsiTBZB3et0s3auNUbHlYdYNp4VKa3sUZqH5AcD3OKzU/KDGXjQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.2.tgz",
+      "integrity": "sha512-5wDnoIfC75zJ2MSHv5SSzTlRL2z7jQMbqQ5jrzottuq2p3oBObv8pD/JpXWu8pRaimaxNr3/Bs/KZIGVXxJ7hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -183,81 +220,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.1.tgz",
-      "integrity": "sha512-BXZw+C+gsWL7pZvbnhJUnCXASiDLGcQxVV7h55Pyh2DmSzwdZIVccE5xc9RVD2trtrhIqk5smuODTxtaZqd0IA==",
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.2.tgz",
+      "integrity": "sha512-da+SC6ikpza98W7C5ChsKEQDvZc8PQLQ0sxmQ5yMRsHpdD3iPKnclJA6ViB5Nr5T9qOX+IDswC6AyqY4V3rtug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.1.tgz",
-      "integrity": "sha512-9g/ceZrZTqA62FA3588Xj0onRPjDNfu0pVQqefK0rrHp9H6Wblph/YmzGjZ2g8uqbTh0ZGIvAGCzErU8f7MHpA==",
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.2.tgz",
+      "integrity": "sha512-Y8kEcPqCiIEeaGv83l9RRA09mfYECqAJHNnOyEtZc9UirI6XBMUyFVss/sSeYUiV/Lf30hkbWcl00V1uXsf86Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.1.tgz",
-      "integrity": "sha512-cZTIrGyAP+W4A6jDVwvWM/JOaoJKQkD/2a5eLUEeNdKAD45jN7BCpsMDONyhZlosLa4UwL8uiINQzj4iFy9nqg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.2.tgz",
+      "integrity": "sha512-5zmobuCQqFZkx+84Nt+suL7vo6jTh2CfAs2ndDSeTS2QHvnzP8YEEGWtWftjyACI0cK/FuH8urWwCHP+d2j8TA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.1.tgz",
-      "integrity": "sha512-N6I3leW0UO8Y9Zv90yo2UHgYGuxZO0mjbvzNxDIJDjO0qECEF7Z9XMvSNeUWXQh/iNDA9lr8MfEy3rmZGIcclw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.2.tgz",
+      "integrity": "sha512-qnGUUuWG66dRMnr33owLsrYIh9fHVxtU4R2rd3SpneAHuoAUcGbDOWNrj05glVU6M8yOqo9gQ22K8zpz0I8Xpg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.1.tgz",
-      "integrity": "sha512-ukU5zeeFs44rQkzv+TRdYard+d+3lmPGs8lPZhHtWE8rfz+LlBSF6s9kP3VQ7LeOYL8Dz0u6tZfnyTrqrumbHQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.2.tgz",
+      "integrity": "sha512-lKZ5uhafMvR7dWCJEyuaeyZitid1I3ICx+k0vGf5x/ktdIQvc7bndCiOPpmIDqUmN26FE3jTehkAzSqee95G2Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.1.tgz",
-      "integrity": "sha512-lCwXyijwPm3vbYHpBXPRomMcD6mgiptmps27gnMCf4HK+u/AOeFPBnIFh4V3l4A5SnP9VRiKBZqwGBpUH0vaTg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.2.tgz",
+      "integrity": "sha512-Zc90xvKWUvxcNicvvTO9Pr/hT2TAnkixOIzJm/KMj5Ptm2pKjk71ngTsdkbRtJQvhZ2Kr9N1YdIjLrNHB5P2xw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -3433,9 +3470,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
-      "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.2.tgz",
+      "integrity": "sha512-aJ1hpGyvfkte3dDAfNbWM4biW4yWZBVz7TIGLZP+v+tWOBgxX3e0N5ZIXHIvmfNNXTI77pcHUx3KmtOk05Ze3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3447,8 +3484,8 @@
         "@babel/preset-typescript": "^7.25.9",
         "@babel/runtime": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3458,17 +3495,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
-      "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.2.tgz",
+      "integrity": "sha512-i0ZNcy0f0WhaOlYVgzLsWhIoEXO9kS3HRoKPtgE6vQtZUq7arKZaYdNBudr3mqCmd+TyOkwtwfHgs1ENj07r5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.10.1",
-        "@docusaurus/cssnano-preset": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/cssnano-preset": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3500,19 +3537,55 @@
         }
       }
     },
-    "node_modules/@docusaurus/core": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
-      "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
+    "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.10.1",
-        "@docusaurus/bundler": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/core": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.2.tgz",
+      "integrity": "sha512-EYByj6nk+aD9KeVxV6Hmo2/nAAT79P21Y82ycTBOBtrmqilloIbIEhgL2/8Xpt2Jz/pgNqHAwyusOGwmbKeJmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/bundler": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3520,7 +3593,7 @@
         "combine-promises": "^1.1.0",
         "commander": "^5.1.0",
         "core-js": "^3.31.1",
-        "detect-port": "^1.5.1",
+        "detect-port": "^2.1.0",
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
         "eval": "^0.1.8",
@@ -3568,9 +3641,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
-      "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.2.tgz",
+      "integrity": "sha512-4gCnHRbJLTloiwfvFAa92tgb2gI4KYhvjfQVYnEaiMO/EgvWfCo1LwytHXen+1oZAN0VAlS0JAPxp3MsvKDa3A==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3583,9 +3656,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
-      "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.2.tgz",
+      "integrity": "sha512-gSEwqtPfCAnC3ZSJY6xL7tcIfgg0vFD39jbv93eakuweyvO2864xR0K+kmKwBhkTCtWRNjuGGnb5rdmkD/ndqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3596,14 +3669,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
-      "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.2.tgz",
+      "integrity": "sha512-9Fd4V/SFjfrVQ0JH5EN0+iPWyFunvTeQE3gfyFeetqPaXMP0OylIjOw16dCuXG4NZJrYdBqwzjh18/h3gRi47w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3638,6 +3711,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
       "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@docusaurus/types": "3.10.1",
@@ -3654,16 +3728,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
-      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.2.tgz",
+      "integrity": "sha512-z5I5ttCXw+8y2gHVZvqAMmUw4Rb0ZzKA5eCPk87SfM/jCKOTvE24yDpPAwwipvug96ij7mOwEHXWw8G4LlWdGA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -3678,19 +3752,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
-      "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.2.tgz",
+      "integrity": "sha512-0cbEnNKf0InmLkhj/+nVRmqEnWEoOE8Mh+2x1qOXI0qYpCnphq4RXknVJ8BvybKRXqYVvbmdMfiJSup+k4tm5w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "cheerio": "1.0.0-rc.12",
         "combine-promises": "^1.1.0",
         "feed": "^4.2.2",
@@ -3712,21 +3786,57 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
-      "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
+    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.2.tgz",
+      "integrity": "sha512-Sqwl4FPoZBDrlY8I2VU2H8O0M91CHp9T8ToMSkTZmjvHCif+1laqfXi6sTk8IfyVS/trN5yNjcWd1bFsGB6W5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3739,6 +3849,47 @@
       },
       "engines": {
         "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+      "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/types": "3.10.2",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -3767,17 +3918,31 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
-      "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-pages": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.2.tgz",
+      "integrity": "sha512-h5R12sZ/vV9EPiVjvIl9YFCOwkpwXes7dQMYt3EvP6Pphu4amHxxTqWxf08Fl5DR8h+oZMbWpFTNw5vKEYfvzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3790,31 +3955,103 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
-      "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
+    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-css-cascade-layers": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.2.tgz",
+      "integrity": "sha512-UkdvQby5OQUKWrw3lLnSTJXQ6VETaUVTuPQX9AABtmFm5h+ifEBx1OQ+LN726Q4byuwBf2ElHkf4qU4hTxdvRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
-      "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
+    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-debug": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.2.tgz",
+      "integrity": "sha512-8vbZNOSCpnsT57EY6CgN7sgRVmx3KTYwO8Uvo2pbxOyb8tbqAwtT9SslqaQ41HbA1v1hpn5RP7u5s2KvRwAFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -3827,15 +4064,51 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
-      "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
+    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.2.tgz",
+      "integrity": "sha512-kMHMBK9j4VAtgd5owwrRLRIi0EjkrpXlX7ePj1+y68XfVZV9I1T4S+koPDm+Hfw2TtnyHvh0uNrDvjz+DjQGVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3844,18 +4117,53 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
-      "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.2.tgz",
+      "integrity": "sha512-Vt90nNFhtAChRe9+it1hcHFgFvETdSnOkL5Bma+p6E/yU2tAYrvvyk+gv+LJGM2ZUkyKuKXLRsZ2Lb0bO7+Vog==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
-        "@types/gtag.js": "^0.0.20",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3864,17 +4172,53 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
-      "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.2.tgz",
+      "integrity": "sha512-MLCffCldysi/R0nzJQP7ZWd0xAoGNnSTiVOo6TTR6mKVGFhE+/XArGe67ZcaZv1uytgQXoXs92VJrgVDrz80rQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3885,18 +4229,54 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
-      "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
+    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.2.tgz",
+      "integrity": "sha512-PODkwg5XetLML3hU/3xpCKJUZ9cqExLaBnD/Fzzwj2VHogLeqnDisLIujae87zuze7T4mCm2A6KEqZkyiz07EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3909,16 +4289,52 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
-      "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-svgr": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.2.tgz",
+      "integrity": "sha512-JgfT3jWM0TJ8Uw0cEcqxHpybngQY1vlBYpuuNO+gEh5iPh5Ar+vxq/u9CFrYsWeXy48BN7Db76Pzp2edNXUQ8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3932,27 +4348,63 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
-      "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
+    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/plugin-content-blog": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/plugin-content-pages": "3.10.1",
-        "@docusaurus/plugin-css-cascade-layers": "3.10.1",
-        "@docusaurus/plugin-debug": "3.10.1",
-        "@docusaurus/plugin-google-analytics": "3.10.1",
-        "@docusaurus/plugin-google-gtag": "3.10.1",
-        "@docusaurus/plugin-google-tag-manager": "3.10.1",
-        "@docusaurus/plugin-sitemap": "3.10.1",
-        "@docusaurus/plugin-svgr": "3.10.1",
-        "@docusaurus/theme-classic": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-search-algolia": "3.10.1",
-        "@docusaurus/types": "3.10.1"
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.2.tgz",
+      "integrity": "sha512-a4B3VczmDl99zK0EufDQYomdJ186WDingjmDXxhN2PNPS9Ty/Y2M5CLFX1KQMRKqRTLiRDKfutzG5IY1FC/ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/plugin-content-blog": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/plugin-content-pages": "3.10.2",
+        "@docusaurus/plugin-css-cascade-layers": "3.10.2",
+        "@docusaurus/plugin-debug": "3.10.2",
+        "@docusaurus/plugin-google-analytics": "3.10.2",
+        "@docusaurus/plugin-google-gtag": "3.10.2",
+        "@docusaurus/plugin-google-tag-manager": "3.10.2",
+        "@docusaurus/plugin-sitemap": "3.10.2",
+        "@docusaurus/plugin-svgr": "3.10.2",
+        "@docusaurus/theme-classic": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-search-algolia": "3.10.2",
+        "@docusaurus/types": "3.10.2"
       },
       "engines": {
         "node": ">=20.0"
@@ -3962,25 +4414,61 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
-      "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/plugin-content-blog": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/plugin-content-pages": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-translations": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.2.tgz",
+      "integrity": "sha512-JqTSLQmqmA9uKWZsD5iwBGJ4JyKB4/yTw6PsSXVPRJG/6GAm/u+add9Iip+hvwP12/AnPNztrdxsI14NJW4KeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/plugin-content-blog": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/plugin-content-pages": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-translations": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -4003,16 +4491,71 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
-      "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+      "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/types": "3.10.2",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-common": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.2.tgz",
+      "integrity": "sha512-R9b/vMpK1yye6hNZTA6x/ivRv+at6GhxnXcxkpzCGzO1R1RwiquqiFg2wMFh6aqlJTpWRFKpFD2TzCDQcyOU0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4031,17 +4574,72 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.1.tgz",
-      "integrity": "sha512-2gxpmln8Pc4EN1oWzshQEx2HTs67jk14v7MmgqGs8ZU7Nm8oihg+fTouof2u4vN8DtB3Fln4cDJu4UprSX1S3Q==",
+    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+      "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/types": "3.10.2",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-mermaid": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.2.tgz",
+      "integrity": "sha512-Stssh5MYQJ+EdYugUXf+ZcpeJFQPKXf0KCd/SWp10o3CmXNaOoh5IEgVjVqY1e1XhQf3on4+Y4BnrMiD95E2SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "mermaid": ">=11.6.0",
         "tslib": "^2.6.0"
       },
@@ -4059,21 +4657,76 @@
         }
       }
     },
+    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+      "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/types": "3.10.2",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-mermaid/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
-      "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.2.tgz",
+      "integrity": "sha512-1msxllyhi/5m77JukXtp5UFnUAriwZIC1oJ7MTnpQpCwLTbclJi5BK5n28CTZuSXpQN2ewbbnqRgAhMM6c6ihg==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.19.2",
         "@docsearch/react": "^3.9.0 || ^4.3.2",
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-translations": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-translations": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -4092,9 +4745,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
-      "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.2.tgz",
+      "integrity": "sha512-iv20wrxnyXkY89LM3TzRlzGlt5fIGO5UnaR6UL1ZVfB9RRFjxQFQ6awDrwAc6Km8Y5gD8pInuwYPF+6/TiCxXA==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4115,6 +4768,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
       "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4137,6 +4791,7 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
       "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -4148,21 +4803,21 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
-      "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.2.tgz",
+      "integrity": "sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@11ty/gray-matter": "^1.0.0",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "escape-string-regexp": "^4.0.0",
         "execa": "^5.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "github-slugger": "^1.5.0",
         "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
         "jiti": "^1.20.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
@@ -4180,27 +4835,63 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
-      "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.2.tgz",
+      "integrity": "sha512-x3Dz6jv6iQKBNjBmVTu8p57abMp/VNTUgKBMgRVXJc5444orBTsArv0+cdfrXTiz/VMmHfDRVkPbL7GH2B7T7w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.1",
+        "@docusaurus/types": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0"
       }
     },
-    "node_modules/@docusaurus/utils-validation": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
-      "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
+    "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/utils-validation": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.2.tgz",
+      "integrity": "sha512-sn8unbDfUL585NtR3cwHefPicOyaHvPaX7VD0aOg/siIxUBoKyKKaGEqzJZDS64mM43TnxurkYDtmB1wsJlZsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4233,6 +4924,28 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@docusaurus/utils/node_modules/js-yaml": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
@@ -4253,6 +4966,20 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -5764,12 +6491,6 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
-    "node_modules/@types/gtag.js": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
-      "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
-      "license": "MIT"
-    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -6300,12 +7021,12 @@
       }
     },
     "node_modules/address": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
+      "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -6367,34 +7088,34 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.1.tgz",
-      "integrity": "sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.2.tgz",
+      "integrity": "sha512-OyacJsaeuLUvGWOynNqYc6sx88XvyoG39wMT8SYqL3l9wwaorDW/LPRbUPfhzw0bWsUWzNCZTnFYOrWFBKsUaw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.21.1",
-        "@algolia/client-abtesting": "5.55.1",
-        "@algolia/client-analytics": "5.55.1",
-        "@algolia/client-common": "5.55.1",
-        "@algolia/client-insights": "5.55.1",
-        "@algolia/client-personalization": "5.55.1",
-        "@algolia/client-query-suggestions": "5.55.1",
-        "@algolia/client-search": "5.55.1",
-        "@algolia/ingestion": "1.55.1",
-        "@algolia/monitoring": "1.55.1",
-        "@algolia/recommend": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/abtesting": "1.21.2",
+        "@algolia/client-abtesting": "5.55.2",
+        "@algolia/client-analytics": "5.55.2",
+        "@algolia/client-common": "5.55.2",
+        "@algolia/client-insights": "5.55.2",
+        "@algolia/client-personalization": "5.55.2",
+        "@algolia/client-query-suggestions": "5.55.2",
+        "@algolia/client-search": "5.55.2",
+        "@algolia/ingestion": "1.55.2",
+        "@algolia/monitoring": "1.55.2",
+        "@algolia/recommend": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.1.tgz",
-      "integrity": "sha512-6ck2YFudF2Pje7szQoPBiRFTGfd+1I+0I/WfLPGn0bj1kvrFoOQmNyedNiDxTk3/r4IfSLDYk+RA4G7u8H6+yA==",
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.2.tgz",
+      "integrity": "sha512-SaV+rZM3drExb0punEYYjT+sNcH74YFwN8ocjya7IDOyQvKWeQpEaSMVG3+IGTVos+feuatj7ljQ4BXlXdUp3w==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -8874,20 +9595,19 @@
       "license": "MIT"
     },
     "node_modules/detect-port": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
-      "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz",
+      "integrity": "sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==",
       "license": "MIT",
       "dependencies": {
-        "address": "^1.0.1",
-        "debug": "4"
+        "address": "^2.0.1"
       },
       "bin": {
-        "detect": "bin/detect-port.js",
-        "detect-port": "bin/detect-port.js"
+        "detect": "dist/commonjs/bin/detect-port.js",
+        "detect-port": "dist/commonjs/bin/detect-port.js"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/devlop": {
@@ -9274,19 +9994,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esrecurse": {
@@ -10145,43 +10852,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -14224,9 +14894,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -14908,9 +15578,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16569,15 +17239,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17599,12 +18260,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -17974,16 +18635,6 @@
         "websocket-driver": "^0.7.4"
       }
     },
-    "node_modules/sockjs/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/sort-css-media-queries": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.2.0.tgz",
@@ -18069,12 +18720,6 @@
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/srcset": {
       "version": "4.0.0",
@@ -18297,9 +18942,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "serialize-javascript": ">=7.0.5",
+    "uuid": ">=11.1.1"
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes three open Dependabot security alerts by adding `overrides` in `package.json` to force patched versions of `serialize-javascript` and `uuid`. Both are transitive dependencies that cannot be updated via a direct bump — `serialize-javascript` is locked by Docusaurus's bundler chain, and `uuid` 8.x is locked by `sockjs` inside `webpack-dev-server`.

Alerts addressed:
- [#28](https://github.com/openmcp-project/docs/security/dependabot/28) — `serialize-javascript` <=7.0.4: RCE via `RegExp.flags` / `Date.prototype.toISOString()` (high)
- [#63](https://github.com/openmcp-project/docs/security/dependabot/63) — `serialize-javascript` <=7.0.4: CPU exhaustion DoS (moderate)
- [#64](https://github.com/openmcp-project/docs/security/dependabot/64) — `uuid` <11.1.1: missing buffer bounds check in v3/v5/v6 (moderate)

`npm audit` reports 0 vulnerabilities after this change.

**Which issue(s) this PR fixes**:
Closes Dependabot alerts #28, #63, #64

**Special notes for your reviewer**:
The `overrides` field is an npm v8+ feature that forces a specific version for a package regardless of what transitive dependencies request. This is the standard approach when a vulnerable package cannot be updated via the direct dependency chain. The downside is that if a future Docusaurus or sockjs release genuinely requires an older version of these packages, it would break — but that's unlikely given both bumps are non-breaking minor/patch versions.

**Release note**:
```bugfix developer
Resolve serialize-javascript (RCE, DoS) and uuid (buffer overread) CVEs via npm overrides
```