### PR TITLE
feat: re-add ADR section to navbar and developers overview

### DIFF
--- a/docs/developers/00-overview.mdx
+++ b/docs/developers/00-overview.mdx
@@ -5,7 +5,7 @@ id: overview
 
 import IconContainer from '@site/src/components/IconContainer';
 import PersonaCards from '@site/src/components/PersonaCards';
-import { Users } from 'lucide-react';
+import { Users, FileText } from 'lucide-react';
 
 # Overview
 
@@ -18,6 +18,23 @@ Whether you're a beginner or an experienced developer, this guide will help you 
 ## Getting Started
 
 Check our guide on [how to create a Service Provider](/developers/serviceprovider/develop) to turn the next Kubernetes-native application into an as-a-Service offering.
+
+## Architecture Decision Records
+
+Curious about *why* things are built the way they are? Our ADRs document the key technical decisions behind OpenControlPlane — the context, the options considered, and the rationale for each choice.
+
+<div className="reference-grid">
+
+<div className="reference-card reference-card-compact">
+  <IconContainer size={48} compact>
+    <FileText size={48} />
+  </IconContainer>
+  <h3>Browse ADRs</h3>
+  <p>Explore architectural decisions that shape OpenControlPlane — from cluster autonomy to discoverable components.</p>
+  <a href="/adrs" className="reference-link">View all ADRs →</a>
+</div>
+
+</div>
 
 ## Join the Community
 

--- a/docs/developers/00-overview.mdx
+++ b/docs/developers/00-overview.mdx
@@ -19,6 +19,21 @@ Whether you're a beginner or an experienced developer, this guide will help you 
 
 Check our guide on [how to create a Service Provider](/developers/serviceprovider/develop) to turn the next Kubernetes-native application into an as-a-Service offering.
 
+## Join the Community
+
+<div className="reference-grid">
+
+<div className="reference-card reference-card-compact">
+  <IconContainer size={48} compact>
+    <Users size={48} />
+  </IconContainer>
+  <h3>Join SIG Extensibility</h3>
+  <p>Connect with developers building providers and extensions for OpenControlPlane.</p>
+  <a href="/community/overview#sig-extensibility" className="reference-link">Community Hub →</a>
+</div>
+
+</div>
+
 ## Architecture Decision Records
 
 Curious about *why* things are built the way they are? Our ADRs document the key technical decisions behind OpenControlPlane — the context, the options considered, and the rationale for each choice.
@@ -32,21 +47,6 @@ Curious about *why* things are built the way they are? Our ADRs document the key
   <h3>Browse ADRs</h3>
   <p>Explore architectural decisions that shape OpenControlPlane — from cluster autonomy to discoverable components.</p>
   <a href="/adrs" className="reference-link">View all ADRs →</a>
-</div>
-
-</div>
-
-## Join the Community
-
-<div className="reference-grid">
-
-<div className="reference-card reference-card-compact">
-  <IconContainer size={48} compact>
-    <Users size={48} />
-  </IconContainer>
-  <h3>Join SIG Extensibility</h3>
-  <p>Connect with developers building providers and extensions for OpenControlPlane.</p>
-  <a href="/community/overview#sig-extensibility" className="reference-link">Community Hub →</a>
 </div>
 
 </div>

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -130,6 +130,7 @@ const config: Config = {
           position: 'left',
           label: 'Build Together',
         },
+        {to: '/adrs', label: 'ADRs', position: 'left'},
         {
           type: 'docSidebar',
           sidebarId: 'communitySidebar',


### PR DESCRIPTION
## Summary

ADRs were removed from the navbar during the #39 redesign. This PR restores visibility.

## Changes

- **Navbar**: Re-adds the `ADRs` link (left-aligned, next to the other primary nav items) pointing to `/adrs`
- **Developers overview**: Adds an _Architecture Decision Records_ section between "Getting Started" and "Join the Community" — a fitting spot for the developer audience who wants to understand the design rationale behind OpenControlPlane

The ADR section includes a card with a description and a direct link to browse all records.

## Preview

```
Navbar: Get Started | Run Your Platform | Build Together | ADRs          Community | CRD Browser | GitHub
```

Developers overview page gains:
> ### Architecture Decision Records
> Curious about *why* things are built the way they are? Our ADRs document the key technical decisions...
> [Browse ADRs card → /adrs]