### PR TITLE
docs(reference): add ESO CRD, rename section, reorganise overview

### DIFF
--- a/docs/reference/00-overview.md
+++ b/docs/reference/00-overview.md
@@ -67,9 +67,9 @@ Resources that end users interact with to consume platform capabilities.
 
 </div>
 
-## Service Providers
+## Services
 
-Available service providers that can be deployed within control planes.
+Available services that can be deployed within control planes.
 
 <div className="reference-grid">
 
@@ -197,7 +197,7 @@ CRD definitions are maintained across multiple repositories:
 
 - **Core & Operator CRDs**: [openmcp-operator](https://github.com/openmcp-project/openmcp-operator/tree/main/api/crds/manifests)
 - **Project & Workspace CRDs**: [project-workspace-operator](https://github.com/openmcp-project/project-workspace-operator/tree/main/api/crds/manifests)
-- **Service Providers**:
+- **Services**:
   - Crossplane: [service-provider-crossplane](https://github.com/openmcp-project/service-provider-crossplane/tree/main/api/crds/manifests)
   - Landscaper: [service-provider-landscaper](https://github.com/openmcp-project/service-provider-landscaper/tree/main/api/crds/manifests)
   - Velero: [service-provider-velero](https://github.com/openmcp-project/service-provider-velero/tree/main/api/crds/manifests)

--- a/docs/reference/00-overview.md
+++ b/docs/reference/00-overview.md
@@ -93,6 +93,15 @@ Available service providers that can be deployed within control planes.
 
 <div className="reference-card">
   <div className="reference-icon-container reference-icon-container-standard">
+    <img src="/img/platform/tower.png" alt="External Secrets Operator" className="reference-icon-large" />
+  </div>
+  <h3>External Secrets Operator</h3>
+  <p>Secrets synchronisation service using the External Secrets Operator.</p>
+  <a href="/reference/services/external-secrets" className="reference-link">View CRD →</a>
+</div>
+
+<div className="reference-card">
+  <div className="reference-icon-container reference-icon-container-standard">
     <img src="/img/platform/tower_velero.png" alt="Velero" className="reference-icon-large" />
   </div>
   <h3>Velero</h3>
@@ -194,3 +203,4 @@ CRD definitions are maintained across multiple repositories:
   - Velero: [service-provider-velero](https://github.com/openmcp-project/service-provider-velero/tree/main/api/crds/manifests)
   - OCM: [service-provider-ocm](https://github.com/open-component-model/service-provider-ocm/tree/main/api/crds/manifests)
   - kro: [service-provider-kro](https://github.com/openmcp-project/service-provider-kro/tree/main/api/crds/manifests)
+  - External Secrets Operator: [service-provider-external-secrets](https://github.com/openmcp-project/service-provider-external-secrets/tree/main/api/crds/manifests)

--- a/docs/reference/00-overview.md
+++ b/docs/reference/00-overview.md
@@ -56,14 +56,6 @@ Resources that end users interact with to consume platform capabilities.
   <a href="/reference/core/project" className="reference-link">View CRD →</a>
 </div>
 
-<div className="reference-card">
-  <div className="reference-icon-container reference-icon-container-standard">
-    <img src="/img/platform/tower.png" alt="ServiceProvider" className="reference-icon-large" />
-  </div>
-  <h3>ServiceProvider</h3>
-  <p>Delivers consumable services to customers via ControlPlanes.</p>
-  <a href="/reference/operator/providers/serviceprovider" className="reference-link">View CRD →</a>
-</div>
 
 </div>
 
@@ -136,6 +128,15 @@ Resources that platform operators use to configure and manage the platform infra
 ### General resources
 
 <div className="reference-grid">
+
+<div className="reference-card">
+  <div className="reference-icon-container reference-icon-container-standard">
+    <img src="/img/platform/tower.png" alt="ServiceProvider" className="reference-icon-large" />
+  </div>
+  <h3>ServiceProvider</h3>
+  <p>Delivers consumable services to end users via ControlPlanes.</p>
+  <a href="/reference/operator/providers/serviceprovider" className="reference-link">View CRD →</a>
+</div>
 
 <div className="reference-card">
   <div className="reference-icon-container reference-icon-container-standard">

--- a/docs/reference/services/_category_.json
+++ b/docs/reference/services/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Service Providers",
+  "label": "Services",
   "position": 4
 }

--- a/docs/reference/services/crossplane.md
+++ b/docs/reference/services/crossplane.md
@@ -34,11 +34,14 @@ apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: Crossplane
 metadata:
   name: my-crossplane
-  namespace: my-workspace
 spec:
-  crossplaneVersion: "1.14.0"
-  providerConfigs:
-    - name: default
+  version: "1.19.0"
+  providers:
+    - name: provider-aws
+      version: "1.0.0"
+  functions:
+    - name: function-patch-and-transform
+      version: "0.8.0"
 ```
 
-The Crossplane service provider manages the installation and lifecycle of Crossplane and its providers within your control plane.
+The Crossplane service provider manages the installation and lifecycle of Crossplane, its providers, and functions within your control plane.

--- a/docs/reference/services/external-secrets.md
+++ b/docs/reference/services/external-secrets.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 3
+id: external-secrets
+---
+
+import CRDViewerCompact from '@site/src/components/CRDViewerCompact';
+
+# External Secrets Operator
+
+<div className="crd-header-container">
+  <img src="/img/platform/tower.png" alt="External Secrets Operator" className="crd-header-icon" />
+  <div className="crd-header-text">
+    <p>Delivers the External Secrets Operator as a service within ControlPlanes, enabling secrets synchronisation from external vaults.</p>
+  </div>
+</div>
+
+**API Group:** `external-secrets.services.open-control-plane.io`
+**API Version:** `v1alpha1`
+**Kind:** `ExternalSecretsOperator`
+
+<CRDViewerCompact
+  crdUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-external-secrets/main/api/crds/manifests/external-secrets.services.open-control-plane.io_externalsecretsoperators.yaml"
+  name="ExternalSecretsOperator"
+  description="External Secrets Operator service provider resource"
+  exampleUrl="https://raw.githubusercontent.com/openmcp-project/service-provider-external-secrets/main/test/e2e/onboarding/eso-mcp-a.yaml"
+/>
+
+## Usage
+
+Deploy the External Secrets Operator within a control plane:
+
+```yaml
+apiVersion: external-secrets.services.open-control-plane.io/v1alpha1
+kind: ExternalSecretsOperator
+metadata:
+  name: my-eso
+  namespace: my-workspace
+spec:
+  version: "v2.1.0"
+```
+
+The External Secrets Operator service provider manages the installation and lifecycle of ESO within your control plane, enabling workloads to synchronise secrets from external providers such as AWS Secrets Manager, HashiCorp Vault, and Azure Key Vault.

--- a/docs/reference/services/kro.md
+++ b/docs/reference/services/kro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 id: kro
 ---
 

--- a/docs/reference/services/ocm.md
+++ b/docs/reference/services/ocm.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 id: ocm
 ---
 

--- a/docs/reference/services/velero.md
+++ b/docs/reference/services/velero.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 id: velero
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds External Secrets Operator to the CRD browser
- Renames "Service Providers" section to "Services" (heading + sidebar label)
- Moves ServiceProvider card from End User Resources to Operator Resources > General Resources

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```doc operator
NONE
```