### PR TITLE
docs: add Custom Access Roles tip — no pre-built viewer role

### DIFF
--- a/docs/users/getting-started/01-onboard.md
+++ b/docs/users/getting-started/01-onboard.md
@@ -256,6 +256,10 @@ The `spec.iam` section controls who can access your ControlPlane and what they c
 
 For users authenticating through your identity provider:
 
+:::tip Custom Access Roles
+There are no pre-built roles like `viewer`. Use custom RBAC `ClusterRole` resources to define exactly the permissions you want to give your users — read-only, scoped, or anything in between. See the [Kubernetes RBAC documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to get started.
+:::
+
 ```yaml
 iam:
   oidc:


### PR DESCRIPTION
## Summary

Adds a tip admonition to the Authentication & Authorization section clarifying that there is no pre-built `viewer` role. Users are encouraged to create custom RBAC `ClusterRole` resources to reflect their own access requirements.

Mirrors the same change applied to the SAP-internal docs:
https://github.tools.sap/cloud-orchestration/cloud-orchestration.github.tools.sap/pull/1500

## Changes
- `docs/users/getting-started/01-onboard.md` — add tip before the OIDC example YAML