### PR TITLE
chore(quickstart): update ocpctl version

### DIFF
--- a/docs/operators/01-quickstart.md
+++ b/docs/operators/01-quickstart.md
@@ -54,7 +54,7 @@ To persist across reboots, add both lines to `/etc/sysctl.d/99-kind.conf`.
 ## Install ocpctl
 
 ```shell
-go install github.com/openmcp-project/ocpctl@v0.4.0
+go install github.com/openmcp-project/ocpctl@v0.4.1
 ```
 
 Or download a pre-built binary from the [releases page](https://github.com/openmcp-project/ocpctl/releases/latest).


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a new version of [ocpctl@v0.4.1](https://github.com/openmcp-project/ocpctl/releases/tag/v0.4.1) and the quickstart guide should use the lastest version 🚀 

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```