### PR TITLE
docs: add interactive ControlPlane lifecycle demo

### DIFF
--- a/docs/users/concepts/controlplane-demo.mdx
+++ b/docs/users/concepts/controlplane-demo.mdx
@@ -1,0 +1,37 @@
+---
+sidebar_position: 10
+id: controlplane-demo
+title: Interactive Demo — ControlPlane
+---
+
+import ControlPlaneDemo from '@site/src/components/ControlPlaneDemo';
+
+# Interactive Demo: ControlPlane Lifecycle
+
+Experience how **OpenControlPlane** provisions and manages a `ControlPlane` — entirely in your browser, no cluster required.
+
+This demo walks you through the full lifecycle:
+
+1. **Apply** a `ControlPlane` manifest to the Onboarding Cluster
+2. **Watch** the operator reconcile and delegate to the Cluster Provider
+3. **See** the new ControlPlane cluster come up
+4. **Connect** and start deploying your resources
+
+---
+
+<ControlPlaneDemo />
+
+---
+
+## What just happened?
+
+- You wrote a **single manifest** declaring the desired state of a `ControlPlane`.
+- The **openmcp-operator** on the Platform Cluster picked it up and orchestrated cluster creation via the configured Cluster Provider (e.g. Gardener).
+- Once ready, a dedicated Kubernetes cluster was spun up — your **ControlPlane** — isolated from other tenants.
+- You connected to it directly using `kubectl` with the context written by the operator.
+
+## Next steps
+
+- [ControlPlane CRD reference](/reference/core/controlplane)
+- [Getting started guide](/users/getting-started)
+- [Configure a Cluster Provider](/operators/overview)

--- a/src/components/ControlPlaneDemo/ArchDiagram.js
+++ b/src/components/ControlPlaneDemo/ArchDiagram.js
@@ -1,0 +1,197 @@
+import React, { useEffect, useRef } from 'react';
+import styles from './styles.module.css';
+
+const COLORS = {
+  onboarding:      '#2CE0BF',
+  platform:        '#60a5fa',
+  clusterProvider: '#f59e0b',
+  controlplane:    '#a78bfa',
+  terminal:        '#98989f',
+};
+
+// Box layout (viewBox 100x70)
+// Left col: Onboarding (top), Platform (mid)
+// Right col: ControlPlane (tall)
+// Bottom: ClusterProvider spans full width
+const BOXES = {
+  onboarding:      { x: 2,  y: 2,  w: 44, h: 22 },
+  platform:        { x: 2,  y: 28, w: 44, h: 22 },
+  clusterProvider: { x: 2,  y: 56, w: 96, h: 12 },
+  controlplane:    { x: 54, y: 2,  w: 44, h: 48 },
+};
+
+function boxCenter(key) {
+  // 'terminal' is below the diagram — map it to just outside the bottom of onboarding box
+  if (key === 'terminal') {
+    const ob = BOXES.onboarding;
+    return { x: ob.x + ob.w / 2, y: 75 }; // below viewBox bottom (70), ball animates in from below
+  }
+  const b = BOXES[key];
+  if (!b) return { x: 50, y: 35 };
+  return { x: b.x + b.w / 2, y: b.y + b.h / 2 };
+}
+
+// Animated ball as a React component using requestAnimationFrame
+function Ball({ from, to, color, onDone }) {
+  const circleRef = useRef(null);
+  const startRef = useRef(null);
+  const DURATION = 900; // ms
+
+  useEffect(() => {
+    const fc = boxCenter(from);
+    const tc = boxCenter(to);
+
+    function frame(ts) {
+      if (!startRef.current) startRef.current = ts;
+      const elapsed = ts - startRef.current;
+      const t = Math.min(elapsed / DURATION, 1);
+      // ease in-out
+      const ease = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+      const cx = fc.x + (tc.x - fc.x) * ease;
+      const cy = fc.y + (tc.y - fc.y) * ease;
+      const opacity = t < 0.85 ? 1 : (1 - t) / 0.15;
+      if (circleRef.current) {
+        circleRef.current.setAttribute('cx', cx);
+        circleRef.current.setAttribute('cy', cy);
+        circleRef.current.setAttribute('opacity', opacity);
+      }
+      if (t < 1) {
+        requestAnimationFrame(frame);
+      } else {
+        if (onDone) onDone();
+      }
+    }
+    requestAnimationFrame(frame);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fc = boxCenter(from);
+  return (
+    <circle
+      ref={circleRef}
+      cx={fc.x}
+      cy={fc.y}
+      r="2"
+      fill={color}
+    />
+  );
+}
+
+function BoxSvg({ id, show, spawned, healthy, applied }) {
+  if (!show && !spawned) return null;
+  const b = BOXES[id];
+  const color = COLORS[id];
+
+  return (
+    <g className={spawned && !show ? styles.svgPopIn : undefined}>
+      <rect
+        x={b.x} y={b.y} width={b.w} height={b.h}
+        rx="2"
+        fill="#1a1a1f"
+        stroke={color}
+        strokeWidth="0.8"
+        opacity="0.95"
+      />
+      {/* label */}
+      <text
+        x={b.x + 2} y={b.y + 5}
+        fontSize="3"
+        fontWeight="bold"
+        fill={color}
+        style={{ textTransform: 'uppercase', letterSpacing: '0.04em' }}
+      >
+        {id === 'onboarding' ? 'Onboarding Cluster' :
+         id === 'platform' ? 'Platform Cluster' :
+         id === 'clusterProvider' ? 'Cluster Provider' :
+         'ControlPlane Cluster'}
+      </text>
+      {/* CR resource card inside onboarding box after apply */}
+      {id === 'onboarding' && applied && (
+        <g className={styles.svgPopIn}>
+          <rect x={b.x + 2} y={b.y + 8} width={b.w - 4} height="12" rx="1.5" fill="#0d1a14" stroke="#2CE0BF" strokeWidth="0.5" />
+          <text x={b.x + 4} y={b.y + 12} fontSize="2.2" fill="#2CE0BF" fontWeight="bold">ManagedControlPlane</text>
+          <text x={b.x + 4} y={b.y + 15.5} fontSize="2.2" fill="#dfdfd6">name: my-control-plane</text>
+          <text x={b.x + 4} y={b.y + 18.5} fontSize="2" fill="#98989f">namespace: my-workspace</text>
+        </g>
+      )}
+      {id === 'clusterProvider' && (
+        <>
+          <text x={b.x + 2} y={b.y + 9} fontSize="2.4" fill="#6a6a71">e.g. Gardener</text>
+          <TagRect x={b.x + 24} y={b.y + 5.5} label="provisions K8s clusters" />
+        </>
+      )}
+      {/* tags */}
+      {id === 'onboarding' && (
+        <>
+          <TagRect x={b.x + 2} y={b.y + 11} label="kubectl" />
+          <TagRect x={b.x + 2} y={b.y + 17} label="ManagedControlPlane CR" />
+        </>
+      )}
+      {id === 'platform' && (
+        <TagRect x={b.x + 2} y={b.y + 11} label="openmcp-operator" />
+      )}
+      {id === 'controlplane' && (
+        <>
+          <TagRect x={b.x + 2} y={b.y + 11} label="Kubernetes API" />
+          <TagRect x={b.x + 2} y={b.y + 17} label="your resources" />
+          {healthy && (
+            <>
+              <circle cx={b.x + 3} cy={b.y + 24} r="1.2" fill="#2CE0BF" />
+              <text x={b.x + 6} y={b.y + 25.5} fontSize="2.5" fill="#2CE0BF" fontWeight="bold">crossplane — healthy</text>
+            </>
+          )}
+        </>
+      )}
+    </g>
+  );
+}
+
+function TagRect({ x, y, label }) {
+  return (
+    <g>
+      <rect x={x} y={y} width={label.length * 1.55 + 2} height="4.5" rx="1" fill="#2a2a30" />
+      <text x={x + 1} y={y + 3.2} fontSize="2.4" fill="#98989f">{label}</text>
+    </g>
+  );
+}
+
+export default function ArchDiagram({
+  show = {},
+  ballStep = -1,
+  spawnedCP = false,
+  crossplaneHealthy = false,
+  ballSequence = [],
+  applied = false,
+}) {
+  const currentBall = ballStep >= 0 && ballStep < ballSequence.length
+    ? ballSequence[ballStep]
+    : null;
+
+  return (
+    <div className={styles.archWrapper}>
+      <svg
+        viewBox="0 0 100 70"
+        preserveAspectRatio="none"
+        style={{ width: '100%', height: '100%', display: 'block' }}
+      >
+        <BoxSvg id="clusterProvider" show={show.clusterProvider} spawned={false} applied={applied} />
+        <BoxSvg id="onboarding"      show={show.onboarding}      spawned={false} applied={applied} />
+        <BoxSvg id="platform"        show={show.platform}        spawned={false} applied={applied} />
+        <BoxSvg id="controlplane"    show={false}                spawned={spawnedCP} healthy={crossplaneHealthy} applied={applied} />
+
+        {currentBall && (
+          <Ball
+            key={ballStep}
+            from={currentBall.from}
+            to={currentBall.to}
+            color={COLORS[currentBall.from] || '#fff'}
+          />
+        )}
+      </svg>
+
+      {currentBall && (
+        <div className={styles.ballLabel}>{currentBall.label}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ControlPlaneDemo/FakeTerminal.js
+++ b/src/components/ControlPlaneDemo/FakeTerminal.js
@@ -1,0 +1,113 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styles from './styles.module.css';
+
+const TARGET = 'kubectl apply -f controlplane.yaml';
+
+export default function FakeTerminal({ onApply, applied, crReady, onReset }) {
+  const [typed, setTyped] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const termRef = useRef(null);
+
+  // Reset when parent resets
+  useEffect(() => {
+    if (!applied) {
+      setTyped('');
+      setSubmitted(false);
+    }
+  }, [applied]);
+
+  function handleKey(e) {
+    if (submitted) return;
+
+    // Prevent ALL default browser actions (scroll, tab, etc.)
+    if (!e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+    }
+
+    if (e.key === 'Enter') {
+      if (typed.trim() === TARGET) {
+        setSubmitted(true);
+        onApply();
+      } else {
+        setTyped(''); // wrong — clear
+      }
+      return;
+    }
+    if (e.key === 'Backspace') {
+      setTyped(t => t.slice(0, -1));
+      return;
+    }
+    if (e.key.length === 1) {
+      setTyped(t => t + e.key);
+    }
+  }
+
+  function handleReset() {
+    setTyped('');
+    setSubmitted(false);
+    onReset();
+    setTimeout(() => termRef.current?.focus(), 50);
+  }
+
+  const isCorrectSoFar = TARGET.startsWith(typed);
+  const focused = !submitted;
+
+  return (
+    <div
+      ref={termRef}
+      className={styles.terminalPane}
+      tabIndex={0}
+      onKeyDown={handleKey}
+      onClick={() => !submitted && termRef.current?.focus()}
+      style={{ cursor: submitted ? 'default' : 'text', outline: 'none' }}
+    >
+      <div className={styles.terminalBar}>
+        <span className={styles.termDot} style={{ background: '#ff5f56' }} />
+        <span className={styles.termDot} style={{ background: '#ffbd2e' }} />
+        <span className={styles.termDot} style={{ background: '#27c93f' }} />
+        <span className={styles.termTitle} style={{ color: '#2CE0BF' }}>onboarding-cluster</span>
+      </div>
+      <div className={styles.terminalBody}>
+        {!submitted && (
+          <>
+            <div className={styles.termLine}>
+              <span className={styles.termPrompt} style={{ color: '#2CE0BF' }}>$ </span>
+              <span
+                className={styles.termCmd}
+                style={{ color: isCorrectSoFar ? '#dfdfd6' : '#ef4444' }}
+              >
+                {typed}
+              </span>
+              <span className={styles.cursor}>█</span>
+            </div>
+            {typed.length === 0 && (
+              <div className={styles.termHint}>
+                Click here, then type: <code>{TARGET}</code>
+              </div>
+            )}
+          </>
+        )}
+        {submitted && (
+          <>
+            <div className={styles.termLine}>
+              <span className={styles.termPrompt} style={{ color: '#2CE0BF' }}>$ </span>
+              <span className={styles.termCmd}>{TARGET}</span>
+            </div>
+            <div className={styles.termOutput}>
+              managedcontrolplane.core.openmcp.cloud/my-control-plane created
+            </div>
+            {crReady && (
+              <div className={styles.termSuccess}>✓ ManagedControlPlane is Ready</div>
+            )}
+            {!crReady && (
+              <div className={styles.termPending}>⟳ Waiting for reconciliation…</div>
+            )}
+            <button className={styles.btnSecondary} style={{ marginTop: '0.6rem' }} onClick={handleReset}>
+              ↺ Reset
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ControlPlaneDemo/InteractiveTerminal.js
+++ b/src/components/ControlPlaneDemo/InteractiveTerminal.js
@@ -1,0 +1,126 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styles from './styles.module.css';
+
+/**
+ * Generic interactive terminal — user types the target command themselves.
+ * Props:
+ *   target: string        — the exact command they must type
+ *   contextLabel: string  — shown in the terminal title bar
+ *   contextColor: string  — color for prompt + title
+ *   output: string        — output shown after correct Enter (pre-formatted)
+ *   successMsg: string    — optional green line shown when successReady=true
+ *   successReady: bool    — when true, shows successMsg (for async flows)
+ *   pendingMsg: string    — shown while successReady is false after submit
+ *   disabled: bool        — greys out + blocks input
+ *   onSubmit: fn          — called when correct command is entered
+ */
+export default function InteractiveTerminal({
+  target,
+  contextLabel,
+  contextColor = '#2CE0BF',
+  output,
+  successMsg,
+  successReady = true,
+  pendingMsg,
+  disabled = false,
+  onSubmit,
+}) {
+  const [typed, setTyped] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const termRef = useRef(null);
+
+  // Auto-focus when enabled
+  useEffect(() => {
+    if (!disabled && !submitted && termRef.current) {
+      termRef.current.focus();
+    }
+  }, [disabled, submitted]);
+
+  // Reset when disabled flips back to true (parent reset)
+  const prevDisabled = useRef(disabled);
+  useEffect(() => {
+    if (!prevDisabled.current && disabled) {
+      setTyped('');
+      setSubmitted(false);
+    }
+    prevDisabled.current = disabled;
+  }, [disabled]);
+
+  function handleKey(e) {
+    if (disabled || submitted) return;
+    if (!e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+    }
+    if (e.key === 'Enter') {
+      if (typed.trim() === target) {
+        setSubmitted(true);
+        if (onSubmit) onSubmit();
+      } else {
+        setTyped('');
+      }
+      return;
+    }
+    if (e.key === 'Backspace') {
+      setTyped(t => t.slice(0, -1));
+      return;
+    }
+    if (e.key.length === 1) {
+      setTyped(t => t + e.key);
+    }
+  }
+
+  const isCorrectSoFar = target.startsWith(typed);
+
+  return (
+    <div
+      ref={termRef}
+      className={styles.terminalPane}
+      tabIndex={disabled ? -1 : 0}
+      onKeyDown={handleKey}
+      onClick={() => !disabled && !submitted && termRef.current?.focus()}
+      style={{ cursor: disabled || submitted ? 'default' : 'text', outline: 'none' }}
+    >
+      <div className={styles.terminalBar}>
+        <span className={styles.termDot} style={{ background: '#ff5f56' }} />
+        <span className={styles.termDot} style={{ background: '#ffbd2e' }} />
+        <span className={styles.termDot} style={{ background: '#27c93f' }} />
+        <span className={styles.termTitle} style={{ color: contextColor }}>{contextLabel}</span>
+      </div>
+      <div className={styles.terminalBody}>
+        {!submitted && (
+          <>
+            <div className={styles.termLine}>
+              <span className={styles.termPrompt} style={{ color: contextColor }}>$ </span>
+              <span className={styles.termCmd} style={{ color: isCorrectSoFar ? '#dfdfd6' : '#ef4444' }}>
+                {typed}
+              </span>
+              {!disabled && <span className={styles.cursor}>█</span>}
+            </div>
+            {typed.length === 0 && (
+              <div className={styles.termHint}>
+                {disabled
+                  ? '(complete the previous step first)'
+                  : <span>Click here, then type: <code>{target}</code></span>}
+              </div>
+            )}
+          </>
+        )}
+        {submitted && (
+          <>
+            <div className={styles.termLine}>
+              <span className={styles.termPrompt} style={{ color: contextColor }}>$ </span>
+              <span className={styles.termCmd}>{target}</span>
+            </div>
+            {output && <pre className={styles.termOutput}>{output}</pre>}
+            {successMsg && successReady && (
+              <div className={styles.termSuccess}>{successMsg}</div>
+            )}
+            {pendingMsg && !successReady && (
+              <div className={styles.termPending}>{pendingMsg}</div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ControlPlaneDemo/demo-config.js
+++ b/src/components/ControlPlaneDemo/demo-config.js
@@ -1,0 +1,12 @@
+export const YAML_TEXT = `apiVersion: core.openmcp.cloud/v1alpha1
+kind: ManagedControlPlane
+metadata:
+  name: my-control-plane
+  namespace: my-workspace
+spec:
+  components:
+    crossplane:
+      version: 1.17.1`;
+
+export const CP_NAME = 'my-control-plane';
+export const WORKSPACE = 'my-workspace';

--- a/src/components/ControlPlaneDemo/index.js
+++ b/src/components/ControlPlaneDemo/index.js
@@ -1,0 +1,240 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { YAML_TEXT, CP_NAME, WORKSPACE } from './demo-config';
+import ArchDiagram from './ArchDiagram';
+import InteractiveTerminal from './InteractiveTerminal';
+import styles from './styles.module.css';
+
+function StepBox({ num, title, disabled, children }) {
+  const ref = useRef(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) setVisible(true); },
+      { threshold: 0.1 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`${styles.stepBox} ${visible ? styles.visible : ''} ${disabled ? styles.disabled : ''}`}
+    >
+      <div className={styles.stepHeader}>
+        <div className={styles.stepBadge}>{num}</div>
+        <h3 className={styles.stepTitle}>{title}</h3>
+      </div>
+      <div className={styles.stepContent}>{children}</div>
+    </div>
+  );
+}
+
+function Connector() {
+  return <div className={styles.stepConnector} />;
+}
+
+// Ball animation sequence for step 5 (the reconcile flow)
+// Each entry: { from, to, label, delay }
+const BALL_SEQUENCE = [
+  { from: 'terminal',       to: 'onboarding',      label: 'kubectl apply',       delay: 0 },
+  { from: 'onboarding',     to: 'platform',        label: 'CR observed',          delay: 1400 },
+  { from: 'platform',       to: 'onboarding',      label: 'acknowledged',         delay: 2600 },
+  { from: 'platform',       to: 'clusterProvider', label: 'provision cluster',    delay: 3800 },
+  { from: 'clusterProvider', to: 'platform',       label: 'cluster ready',        delay: 5800 },
+  { from: 'platform',       to: 'controlplane',    label: 'install crossplane',   delay: 7000 },
+  { from: 'controlplane',   to: 'platform',        label: 'crossplane healthy',   delay: 9200 },
+  { from: 'platform',       to: 'onboarding',      label: 'CR Ready',             delay: 10400 },
+];
+
+function ControlPlaneDemoInner() {
+  const [applied, setApplied] = useState(false);
+  const [ballStep, setBallStep] = useState(-1);   // which ball is currently flying
+  const [spawnedCP, setSpawnedCP] = useState(false);
+  const [crossplaneHealthy, setCrossplaneHealthy] = useState(false);
+  const [crReady, setCrReady] = useState(false);
+  const timersRef = useRef([]);
+
+  const clearTimers = () => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  };
+
+  const handleApply = useCallback(() => {
+    if (applied) return;
+    setApplied(true);
+
+    BALL_SEQUENCE.forEach((seq, i) => {
+      const t = setTimeout(() => {
+        setBallStep(i);
+        // At step 3 (cluster provider → platform), spawn the ControlPlane box
+        if (i === 3) {
+          setTimeout(() => setSpawnedCP(true), 900);
+        }
+        // At step 6 (platform → controlplane), mark crossplane healthy after ball arrives
+        if (i === 5) {
+          setTimeout(() => setCrossplaneHealthy(true), 1100);
+        }
+        // At step 7 (platform → onboarding), CR is ready
+        if (i === 7) {
+          setTimeout(() => setCrReady(true), 1100);
+        }
+      }, seq.delay);
+      timersRef.current.push(t);
+    });
+  }, [applied]);
+
+  const handleReset = () => {
+    clearTimers();
+    setApplied(false);
+    setBallStep(-1);
+    setSpawnedCP(false);
+    setCrossplaneHealthy(false);
+    setCrReady(false);
+  };
+
+  return (
+    <div className={styles.demoWrapper}>
+
+      {/* Step 1: Cluster Provider */}
+      <StepBox num={1} title="The Cluster Provider — raw Kubernetes on demand">
+        <p className={styles.stepDesc}>
+          A <strong>Cluster Provider</strong> is the engine that creates and deletes Kubernetes clusters on request.
+          OpenMCP abstracts the underlying technology (Gardener, kind, …) behind a uniform interface.
+          Platform operators install one cluster provider per environment.
+        </p>
+        <ArchDiagram
+          show={{ clusterProvider: true }}
+          ballStep={-1}
+          spawnedCP={false}
+          crossplaneHealthy={false}
+        />
+      </StepBox>
+
+      <Connector />
+
+      {/* Step 2: Onboarding Cluster */}
+      <StepBox num={2} title="The Onboarding Cluster — where you write your CRs">
+        <p className={styles.stepDesc}>
+          The <strong>Onboarding Cluster</strong> is the Kubernetes cluster you interact with.
+          You <code>kubectl apply</code> a <code>ManagedControlPlane</code> CR here — that is the only action you need to take.
+        </p>
+        <ArchDiagram
+          show={{ clusterProvider: true, onboarding: true }}
+          ballStep={-1}
+          spawnedCP={false}
+          crossplaneHealthy={false}
+        />
+      </StepBox>
+
+      <Connector />
+
+      {/* Step 3: Platform Cluster */}
+      <StepBox num={3} title="The Platform Cluster — where the controllers run">
+        <p className={styles.stepDesc}>
+          The <strong>Platform Cluster</strong> runs the <code>openmcp-operator</code>.
+          It watches the Onboarding Cluster for new <code>ManagedControlPlane</code> CRs and orchestrates
+          all downstream actions — cluster provisioning, component installation, status reporting.
+        </p>
+        <ArchDiagram
+          show={{ clusterProvider: true, onboarding: true, platform: true }}
+          ballStep={-1}
+          spawnedCP={false}
+          crossplaneHealthy={false}
+        />
+      </StepBox>
+
+      <Connector />
+
+      {/* Step 4: The YAML */}
+      <StepBox num={4} title="Define your ManagedControlPlane">
+        <p className={styles.stepDesc}>
+          Declare what you want in a single manifest. Here you request a dedicated control plane
+          with <strong>Crossplane</strong> pre-installed.
+        </p>
+        <pre className={styles.yamlBlock}>{YAML_TEXT}</pre>
+      </StepBox>
+
+      <Connector />
+
+      {/* Step 5: Apply + animated flow */}
+      <StepBox num={5} title="Apply — and watch the reconciliation unfold">
+        <p className={styles.stepDesc}>
+          Type <code>kubectl apply -f controlplane.yaml</code> and press Enter.
+          Watch each message travel between components in the diagram.
+        </p>
+        <ArchDiagram
+          show={{ clusterProvider: true, onboarding: true, platform: true }}
+          ballStep={ballStep}
+          spawnedCP={spawnedCP}
+          crossplaneHealthy={crossplaneHealthy}
+          ballSequence={BALL_SEQUENCE}
+          applied={applied}
+        />
+        <InteractiveTerminal
+          target="kubectl apply -f controlplane.yaml"
+          contextLabel="onboarding-cluster"
+          contextColor="#2CE0BF"
+          output="managedcontrolplane.core.openmcp.cloud/my-control-plane created"
+          successMsg="✓ ManagedControlPlane is Ready"
+          successReady={crReady}
+          pendingMsg="⟳ Waiting for reconciliation…"
+          disabled={applied}
+          onSubmit={handleApply}
+        />
+      </StepBox>
+
+      <Connector />
+
+      {/* Step 6: Connect to ControlPlane */}
+      <StepBox num={6} title="Connect to your ControlPlane" disabled={!crReady}>
+        <p className={styles.stepDesc}>
+          Your <code>ManagedControlPlane</code> is ready. Switch context and verify Crossplane is running:
+        </p>
+        <InteractiveTerminal
+          target="kubectl get deployments -n crossplane-system"
+          contextLabel={`controlplane — ${CP_NAME}`}
+          contextColor="#a78bfa"
+          output={`NAME                      READY   UP-TO-DATE   AVAILABLE
+crossplane                1/1     1            1
+crossplane-rbac-manager   1/1     1            1`}
+          successMsg="✓ Crossplane is installed and healthy"
+          disabled={!crReady}
+        />
+      </StepBox>
+
+      <Connector />
+
+      {/* Step 7: Try it yourself */}
+      <StepBox num={7} title="Try it yourself — locally with Docker">
+        <p className={styles.stepDesc}>
+          Ready to run this for real? The quickstart gets you a full OpenControlPlane environment
+          running locally with Docker in minutes — no cloud account needed.
+        </p>
+        <a className={styles.ctaLink} href="/operators/quickstart">
+          <div className={styles.ctaCard}>
+            <div className={styles.ctaIcon}>🚀</div>
+            <div className={styles.ctaText}>
+              <div className={styles.ctaTitle}>Quickstart — Run locally with Docker</div>
+              <div className={styles.ctaDesc}>Install OpenControlPlane, create your first ControlPlane, and deploy Crossplane — all on your laptop.</div>
+            </div>
+            <div className={styles.ctaArrow}>→</div>
+          </div>
+        </a>
+      </StepBox>
+
+    </div>
+  );
+}
+
+export default function ControlPlaneDemo() {
+  return (
+    <BrowserOnly fallback={<div>Loading interactive demo…</div>}>
+      {() => <ControlPlaneDemoInner />}
+    </BrowserOnly>
+  );
+}

--- a/src/components/ControlPlaneDemo/styles.module.css
+++ b/src/components/ControlPlaneDemo/styles.module.css
@@ -1,0 +1,409 @@
+/* ===== Demo wrapper ===== */
+.demoWrapper {
+  margin: 1.5rem 0;
+  font-family: var(--ifm-font-family-base);
+}
+
+/* ===== Step boxes (BTP-demo style) ===== */
+.stepBox {
+  background: var(--ifm-card-background-color, #202127);
+  border: 1px solid #3c3f44;
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+
+.stepBox.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.stepBox.disabled {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.stepHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.stepBadge {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #049F9A;
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.stepTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color);
+}
+
+.stepContent {
+  /* children flow naturally */
+}
+
+.stepDesc {
+  font-size: 0.9rem;
+  color: var(--ifm-color-content-secondary);
+  line-height: 1.55;
+  margin: 0 0 0.9rem;
+}
+
+.stepConnector {
+  width: 2px;
+  height: 32px;
+  background: #3c3f44;
+  margin: 0 0 0 22px;
+}
+
+/* ===== YAML block ===== */
+.yamlBlock {
+  background: #0d0d0f;
+  border: 1px solid #3c3f44;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: #2CE0BF;
+  font-family: var(--ifm-font-family-monospace);
+  overflow-x: auto;
+  margin: 0;
+}
+
+/* ===== Architecture diagram ===== */
+.archWrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 100 / 70;
+  margin-top: 0.9rem;
+  border: 1px solid #3c3f44;
+  border-radius: 8px;
+  background: #0d0d0f;
+  overflow: hidden;
+}
+
+.archBox {
+  position: absolute;
+  border: 2px solid #3c3f44;
+  border-radius: 7px;
+  padding: 0.5rem 0.7rem;
+  background: #1a1a1f;
+  box-sizing: border-box;
+  transition: border-color 0.35s, box-shadow 0.35s;
+  overflow: hidden;
+}
+
+.archBoxActive {
+  border-color: var(--box-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--box-color) 20%, transparent);
+}
+
+.archBoxSpawned {
+  animation: popIn 0.4s cubic-bezier(0.34,1.56,0.64,1) both;
+}
+
+@keyframes popIn {
+  from { opacity: 0; transform: scale(0.7); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.archBoxLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #98989f;
+  line-height: 1.2;
+}
+
+.archBoxSub {
+  font-size: 0.67rem;
+  color: #6a6a71;
+  margin-top: 1px;
+}
+
+.archBoxTags {
+  margin-top: 0.35rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+}
+
+.archTag {
+  font-size: 0.65rem;
+  background: #2a2a30;
+  color: #98989f;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.archHealthy {
+  margin-top: 0.4rem;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.68rem;
+  color: #2CE0BF;
+  font-weight: 600;
+}
+
+.archHealthyDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #2CE0BF;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.8); }
+}
+
+/* Flying ball (SVG-based, animated via keyframes) */
+.ballSvg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.flyBall {
+  animation: flyAlongPath 1.1s ease-in-out forwards;
+  transform-origin: center;
+}
+
+@keyframes flyAlongPath {
+  0%   { cx: var(--fx); cy: var(--fy); opacity: 1; r: 1.8; }
+  50%  { r: 2.2; }
+  90%  { opacity: 1; }
+  100% { cx: var(--tx); cy: var(--ty); opacity: 0; r: 1.8; }
+}
+
+.ballLabel {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.68rem;
+  color: #98989f;
+  background: rgba(13,13,15,0.85);
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+  pointer-events: none;
+  animation: fadeInOut 1.1s ease-in-out forwards;
+}
+
+@keyframes fadeInOut {
+  0%   { opacity: 0; }
+  15%  { opacity: 1; }
+  80%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* ===== Terminal pane ===== */
+.terminalPane {
+  background: #0d0d0f;
+  border: 1px solid #3c3f44;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 0.75rem;
+}
+
+.terminalBar {
+  background: #1b1b1f;
+  padding: 0.4rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-bottom: 1px solid #2e2e32;
+}
+
+.termDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.termTitle {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  color: #98989f;
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.terminalBody {
+  padding: 0.75rem 1rem;
+  min-height: 64px;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.82rem;
+}
+
+.termLine {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  position: relative;
+}
+
+.termPrompt {
+  margin-right: 4px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.termCmd {
+  color: #dfdfd6;
+}
+
+.termOutput {
+  display: block;
+  margin-top: 0.35rem;
+  color: #98989f;
+  white-space: pre;
+  font-size: 0.78rem;
+}
+
+.termSuccess {
+  margin-top: 0.35rem;
+  color: #2CE0BF;
+  font-weight: 600;
+}
+
+.termPending {
+  margin-top: 0.35rem;
+  color: #98989f;
+  font-style: italic;
+}
+
+.termHint {
+  margin-top: 0.25rem;
+  font-size: 0.78rem;
+  color: #6a6a71;
+}
+
+.cursor {
+  display: inline-block;
+  color: #2CE0BF;
+  animation: blink 0.8s step-end infinite;
+  font-size: 0.9em;
+  margin-left: 1px;
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+
+.hiddenInput {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+/* ===== CTA card (Step 7) ===== */
+.ctaLink {
+  text-decoration: none;
+  display: block;
+  margin-top: 0.5rem;
+}
+
+.ctaCard {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid #049F9A;
+  border-radius: 8px;
+  background: rgba(4, 159, 154, 0.06);
+  transition: background 0.2s, border-color 0.2s;
+  cursor: pointer;
+}
+
+.ctaCard:hover {
+  background: rgba(44, 224, 191, 0.1);
+  border-color: #2CE0BF;
+}
+
+.ctaIcon {
+  font-size: 1.8rem;
+  flex-shrink: 0;
+}
+
+.ctaText {
+  flex: 1;
+}
+
+.ctaTitle {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #2CE0BF;
+  margin-bottom: 0.25rem;
+}
+
+.ctaDesc {
+  font-size: 0.82rem;
+  color: #98989f;
+  line-height: 1.4;
+}
+
+.ctaArrow {
+  font-size: 1.2rem;
+  color: #2CE0BF;
+  flex-shrink: 0;
+}
+.btnPrimary {
+  background: #049F9A;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btnPrimary:hover:not(:disabled) {
+  background: #2CE0BF;
+  color: #012931;
+}
+
+.btnPrimary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btnSecondary {
+  background: transparent;
+  color: #98989f;
+  border: 1px solid #3c3f44;
+  border-radius: 6px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.btnSecondary:hover {
+  border-color: #98989f;
+  color: #dfdfd6;
+}


### PR DESCRIPTION
## Summary

- Adds a 7-step browser-based interactive demo page at `/users/concepts/controlplane-demo`
- Architecture diagram builds up step-by-step (Cluster Provider → Onboarding → Platform → ControlPlane)
- Animated balls show the reconciliation message flow after `kubectl apply`
- User types commands themselves in interactive terminals (Steps 5 & 6)
- Step 7 links to the local quickstart

## Components added

- `src/components/ControlPlaneDemo/` — React component suite (SVG diagram with rAF ball animation, interactive terminals, step boxes with IntersectionObserver)
- `docs/users/concepts/controlplane-demo.mdx` — doc page, auto-picked up by the autogenerated sidebar

## Test plan

- [ ] `npm start` and visit `/users/concepts/controlplane-demo`
- [ ] Steps 1–3: verify diagram boxes appear one by one
- [ ] Step 4: YAML displayed correctly
- [ ] Step 5: type `kubectl apply -f controlplane.yaml`, verify balls animate through all components and ControlPlane box spawns
- [ ] Step 6: type `kubectl get deployments -n crossplane-system` after Step 5 completes
- [ ] Step 7: CTA card links to `/operators/quickstart`
- [ ] No layout shift, no page scroll on spacebar